### PR TITLE
config: refactor library_data into helpers 

### DIFF
--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -1,0 +1,23 @@
+export function getLibraryCodeFromUrl(lib_url, defLibCode="help"){
+  let lib_code = defLibCode;
+  if(lib_url.includes("bu.edu/library/")){
+    // try to get {library_code} from url 'http://www.bu.edu/library/{stone-science}/research/guides/'
+    let lib_url_fragment = lib_url.split("bu.edu/library/")[1] || "";
+    lib_url_fragment = lib_url_fragment.split("/")[0];
+  
+    // set library code based on url fragment
+    if(lib_url_fragment.includes("africa")){ lib_code = "african-studies"; }
+    else if(lib_url_fragment.includes("mugar")){ lib_code = "mugar-memorial"; }
+    else if(lib_url_fragment.includes("med")){ lib_code = "medlib"; }
+    else if(lib_url_fragment.includes("astronom")){ lib_code = "astronomy"; }
+    else if(lib_url_fragment.includes("law")){ lib_code = "lawlibrary"; }
+    else if(lib_url_fragment.includes("music")){ lib_code = "music"; }
+    else if(lib_url_fragment.includes("management")){ lib_code = "pardee"; }
+    else if(lib_url_fragment.includes("pickering")){ lib_code = "pickering"; }
+    else if(lib_url_fragment.includes("sel")){ lib_code = "sel"; }
+    else if(lib_url_fragment.includes("stone")){ lib_code = "stone"; }
+    else if(lib_url_fragment.includes("sthlibrary")){ lib_code = "stone"; }
+    else { lib_code = "help"; }
+  }
+  return lib_code;
+};

--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -1,10 +1,99 @@
+import {_getDataFromFile} from './load_json.js';
+
+const debug = true;
+
+const libraries_data_backup = {
+  "mugar-memorial":{
+    "name":"Mugar Memorial Library",
+    "website":"https://www.bu.edu/library/mugar-memorial/",
+    "address":["771 Commonwealth Avenue","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-2700","email":"ask@bu.edu"},
+    "social":{"facebook":"mugarlib","twitter":"mugarlib","instagram":"mugarlib"}
+  },"african-studies":{
+    "name":"African Studies Library",
+    "website":"https://www.bu.edu/library/african-studies/",
+    "address":["771 Commonwealth Ave, 6th Floor","Boston, MA, 02215"],
+    "contacts":{"phone":"617-353-3726"},
+    "social":{"facebook":"BuAfricanStudiesLibrary","flickr":"123460528@N03"}
+  },"medlib":{
+    "name":"Alumni Medical Library",
+    "website":"https://medlib.bu.edu/",
+    "address":["72 E Concord, L-12","Boston, MA 02118"],
+    "contacts":{"phone":"617-358-2350","fax":"617-358-2347","email":"refquest@bu.edu"},
+  },"astronomy":{
+    "name":"Astronomy Library",
+    "website":"https://www.bu.edu/library/astronomy/",
+    "address":["725 Commonwealth Avenue","Boston, MA 02445"],
+    "contacts":{"phone":"617-353-2625"}
+  },"lawlibrary":{
+    "name":"Fineman & Pappas Law Libraries",
+    "website":"https://www.bu.edu/lawlibrary/",
+    "address":["765 Commonwealth Ave, 2nd Floor","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-8411","text":"1-617-997-4475"}
+  },"hgar":{
+    "name":"Howard Gotlieb Archival Research Center",
+    "website":"http://archives.bu.edu/",
+    "address":["771 Commonwealth Ave, 5th Floor","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3696","fax":"617-353-2838","email":"archives@bu.edu"},
+    "social":{"facebook":"hgarc","twitter":"BUHGARC"}
+  },"music":{
+    "name":"Music Library",
+    "website":"https://www.bu.edu/library/music/",
+    "address":["771 Commonwealth Ave, Floor 2","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3705","email":"musiclib@bu.edu"},
+    "social":{"twitter":"BUMusicLib","facebook":"bumusiclib"}
+  },"pardee":{
+    "name":"Pardee Management Library",
+    "website":"https://www.bu.edu/library/management/",
+    "address":["595 Commonwealth Avenue","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-4301","fax":"617-353-4307","email":"pardstf@bu.edu"},
+    "social":{"twitter":"BUpardeelibrary","facebook":"pardeelibrary"}
+  },"pickering":{
+    "name":"Pickering Educational Resources Library",
+    "website":"https://www.bu.edu/library/pickering-educational/",
+    "address":["2 Silber Way","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3734"},
+    "social":{"twitter":"BUPickeringLib","facebook":"BUPickeringLibrary"}
+  },"sel":{
+    "name":"Science & Engineering Library",
+    "website":"https://www.bu.edu/library/sel/",
+    "address":["38 Cummington Mall","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3733","fax":"617-353-3470"},
+    "social":{"twitter":"BUSciEngLib","tumblr":"buscienglib","instagram":"buscienglib"}
+  },"stone":{
+    "name":"Stone Science Library",
+    "website":"https://www.bu.edu/library/stone-science/",
+    "address":["675 Commonwealth Ave, Floor 2","Boston, MA 02445"],
+    "contacts":{"phone":"617-353-5679"}
+  },"theology":{
+    "name":"School of Theology Library",
+    "website":"https://www.bu.edu/sthlibrary/",
+    "address":["745 Commonwealth Ave, Floor 2","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3034","fax":"617-358-0698","email":"sthlib@bu.edu"},
+    "social":{"twitter":"BUSTHLibrary","facebook":"busthlibrary","instagram":"butheologylibrary"}
+  },"help":{
+    "name":"BU Libraries",
+    "website":"https://askalibrarian.bu.edu/",
+    "address":["771 Commonwealth Avenue","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-2700","email":"ask@bu.edu","text":"617-431-2427"},
+    "social":{"twitter":"BULibNews"}
+  }
+};
+
+export function getLibraryInfoFromCode(lib_code, defLibCode="help"){
+  let libraries_data = /* TODO: _getDataFromFile("lib_info.json") || */ libraries_data_backup;
+  let library_data = libraries_data[lib_code] || libraries_data[defLibCode];
+  if(debug){ console.log(`_lib_info_helper) getting library_data for code: '${lib_code}' with default '${defLibCode}'.`);}
+  return library_data;
+}
+
 export function getLibraryCodeFromUrl(lib_url, defLibCode="help"){
   let lib_code = defLibCode;
   if(lib_url.includes("bu.edu/library/")){
     // try to get {library_code} from url 'http://www.bu.edu/library/{stone-science}/research/guides/'
     let lib_url_fragment = lib_url.split("bu.edu/library/")[1] || "";
     lib_url_fragment = lib_url_fragment.split("/")[0];
-  
+
     // set library code based on url fragment
     if(lib_url_fragment.includes("africa")){ lib_code = "african-studies"; }
     else if(lib_url_fragment.includes("mugar")){ lib_code = "mugar-memorial"; }
@@ -19,5 +108,8 @@ export function getLibraryCodeFromUrl(lib_url, defLibCode="help"){
     else if(lib_url_fragment.includes("sthlibrary")){ lib_code = "stone"; }
     else { lib_code = "help"; }
   }
+  if(!Object.keys(libraries_data_backup).includes(lib_code)){ lib_code = "help"; }
+  if(debug){ console.log(`_lib_info_helper) returning lib_code '${lib_code}' from lib_url '${lib_url}'.`); }
   return lib_code;
-};
+}
+

--- a/src/_helpers/load_json.js
+++ b/src/_helpers/load_json.js
@@ -1,0 +1,12 @@
+let debug = true;
+
+/** make a get request to load the data as json from specified file at particular version */
+export function _getDataFromFile(filename, version){
+  let domain = "https://cdn.jsdelivr.net/gh/bulib/bulib-wc";
+  if(version !== ""){ domain += `@${version}`; }
+  let url = domain+"/data/"+filename;
+  
+  //TODO implement the actual call to load the file
+  if(debug){ console.log(`_load_json) making call to get data from filename: ${filename} with url: ${url}`); }
+  return {};
+}

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -1,7 +1,7 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
 import { getLibraryCodeFromUrl } from '../_helpers/lib_info_helper.js';
 
-const debug = true;
+const debug = false;
 const local = false;
 
 /** Reactive/responsive footer providing slotted middle section and customizable LoCoSo data */
@@ -22,9 +22,8 @@ class BULFooter extends LitElement {
   /** upon the element's first connection to the DOM, get the url and use it to determine $this.library */
   connectedCallback(){
     let current_url = local? "http://www.bu.edu/library/music/research/guides/" : window.location.href;
-    if(debug){ console.log("bulib-footer) calling getLibraryCodeFromUrl() with url: " + current_url); }
     let lib_code = getLibraryCodeFromUrl(current_url);
-    if(debug){ console.log("bulib-footer) library code: " + lib_code); }
+    if(debug){ console.log("bulib-footer) selected library code: " + lib_code); }
     this.library = lib_code;
   }
 

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -1,4 +1,5 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import { getLibraryCodeFromUrl } from '../_helpers/lib_info_helper.js';
 
 const debug = true;
 const local = false;
@@ -21,29 +22,10 @@ class BULFooter extends LitElement {
   /** upon the element's first connection to the DOM, get the url and use it to determine $this.library */
   connectedCallback(){
     let current_url = local? "http://www.bu.edu/library/music/research/guides/" : window.location.href;
-    if(current_url.includes("bu.edu/library/")){
-      // try to get {library_code} from url 'http://www.bu.edu/library/{stone-science}/research/guides/'
-      let lib_url_fragment = current_url.split("bu.edu/library/")[1] || "";
-      lib_url_fragment = lib_url_fragment.split("/")[0];
-      
-      // set library code based on url fragment
-      let lib_code = "help";
-      if(debug){ console.log("bulib-footer) lib_url_fragment: " + lib_url_fragment); }
-      if(lib_url_fragment.includes("africa")){ lib_code = "african-studies"; }
-      else if(lib_url_fragment.includes("mugar")){ lib_code = "mugar-memorial"; }
-      else if(lib_url_fragment.includes("med")){ lib_code = "medlib"; }
-      else if(lib_url_fragment.includes("astronom")){ lib_code = "astronomy"; }
-      else if(lib_url_fragment.includes("law")){ lib_code = "lawlibrary"; }
-      else if(lib_url_fragment.includes("music")){ lib_code = "music"; }
-      else if(lib_url_fragment.includes("management")){ lib_code = "pardee"; }
-      else if(lib_url_fragment.includes("pickering")){ lib_code = "pickering"; }
-      else if(lib_url_fragment.includes("sel")){ lib_code = "sel"; }
-      else if(lib_url_fragment.includes("stone")){ lib_code = "stone"; }
-      else if(lib_url_fragment.includes("sthlibrary")){ lib_code = "stone"; }
-      else { lib_code = "help"; }
-      if(debug){ console.log("bulib-footer) library code: " + lib_code); }
-      this.library = lib_code;
-    }
+    if(debug){ console.log("bulib-footer) calling getLibraryCodeFromUrl() with url: " + current_url); }
+    let lib_code = getLibraryCodeFromUrl(current_url);
+    if(debug){ console.log("bulib-footer) library code: " + lib_code); }
+    this.library = lib_code;
   }
 
   render() {

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -1,6 +1,7 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
 
-const debug = false;
+const debug = true;
+const local = true;
 
 /** Reactive/responsive header with custom subsite display, bulib-search integration */
 class BULHeader extends LitElement {
@@ -62,9 +63,9 @@ class BULHeader extends LitElement {
       </nav>`;
   }
 
-  /** update current properties to inform what to display */
-  init(){
-    let currentUrl = (this.curr_url)? this.curr_url : window.location.href;
+  /** upon connection to the DOM, update current properties to inform what to display */
+  connectedCallback(){
+    let currentUrl = (local)? this.curr_url : window.location.href;
 
     this.curr_library = "";
     if(currentUrl.includes("askalibrarian")){

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -5,65 +5,78 @@ const debug = false;
 /** static LOcation, COntact, SOcial data used by the element */
 const locoso = {
   "mugar-memorial":{
+    "name":"Mugar Memorial Library",
     "website":"https://www.bu.edu/library/mugar-memorial/",
-    "location":{ "address":["Mugar Memorial Library","771 Commonwealth Avenue","Boston, MA 02215"]},
-    "contacts":[{"name":"Reference","phone":"617-353-2700","email":"ask@bu.edu"},{"name":"Circulation","phone":"617-353-3732","email":"mugcirc@bu.edu"},{"name":"Reservation","phone":"617-353-3739","email":"mugarres@bu.edu"}],
+    "address":["771 Commonwealth Avenue","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-2700","email":"ask@bu.edu"},
     "social":{"facebook":"mugarlib","twitter":"mugarlib","instagram":"mugarlib"}
   },"african-studies":{
+    "name":"African Studies Library",
     "website":"https://www.bu.edu/library/african-studies/",
-    "location":{"address":["African Studies Library","771 Commonwealth Ave, 6th Floor","Boston, MA, 02215"]},
-    "contacts":[{"name":"African Studies","phone":"617-353-3726"}],
+    "address":["771 Commonwealth Ave, 6th Floor","Boston, MA, 02215"],
+    "contacts":{"phone":"617-353-3726"},
     "social":{"facebook":"BuAfricanStudiesLibrary","flickr":"123460528@N03"}
   },"medlib":{
+    "name":"Alumni Medical Library",
     "website":"https://medlib.bu.edu/",
-    "location":{"address":["BU Alumni Medical Library","72 E Concord, L-12","Boston, MA 02118"]},
-    "contacts":[{"name":"Main Number","phone":"617-358-2350","fax":"617-358-2347","email":"refquest@bu.edu"},{"name":"Circulation","phone":"617-358-4902"},{"name":"Interlibrary Loan","phone":"617-358-2352"},{"name":"Reference","phone":"617-358-4810"},{"name":"Computer Lab","phone":"617-358-2344","email":"mugarres@bu.edu"}]
+    "address":["72 E Concord, L-12","Boston, MA 02118"],
+    "contacts":{"phone":"617-358-2350","fax":"617-358-2347","email":"refquest@bu.edu"},
   },"astronomy":{
+    "name":"Astronomy Library",
     "website":"https://www.bu.edu/library/astronomy/",
-    "location":{"address":["Astronomy Library","725 Commonwealth Avenue","Boston, MA 02445"]},
-    "contacts":[{"name":"Astronomy Library","phone":"617-353-2625"}]
+    "address":["725 Commonwealth Avenue","Boston, MA 02445"],
+    "contacts":{"phone":"617-353-2625"}
   },"lawlibrary":{
+    "name":"Fineman & Pappas Law Libraries",
     "website":"https://www.bu.edu/lawlibrary/",
-    "location":{"address":["Fineman & Pappas Law Libraries","765 Commonwealth Ave, 2nd Floor","Boston, MA 02215"]},
-    "contacts":[{"name":"Reference Desk","phone":"617-353-8411","text":"1-617-997-4475"}]
+    "address":["765 Commonwealth Ave, 2nd Floor","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-8411","text":"1-617-997-4475"}
   },"hgar":{
+    "name":"Howard Gotlieb Archival Research Center",
     "website":"http://archives.bu.edu/",
-    "location":{"address":["Howard Gotlieb Archival Research Center","771 Commonwealth Ave, 5th Floor","Boston, MA 02215"]},
-    "contacts":[{"phone":"617-353-3696","fax":"617-353-2838","email":"archives@bu.edu"}],
+    "address":["771 Commonwealth Ave, 5th Floor","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3696","fax":"617-353-2838","email":"archives@bu.edu"},
     "social":{"facebook":"hgarc","twitter":"BUHGARC"}
   },"music":{
+    "name":"Music Library",
     "website":"https://www.bu.edu/library/music/",
-    "location":{"address":["Music Library","771 Commonwealth Ave, Floor 2","Boston, MA 02215"]},
-    "contacts":[{"name":"General Inquiries","phone":"617-353-3705","email":"musiclib@bu.edu"}],
+    "address":["771 Commonwealth Ave, Floor 2","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3705","email":"musiclib@bu.edu"},
     "social":{"twitter":"BUMusicLib","facebook":"bumusiclib"}
   },"pardee":{
+    "name":"Pardee Management Library",
     "website":"https://www.bu.edu/library/management/",
-    "location":{"address":["Pardee Management Library","595 Commonwealth Avenue","Boston, MA 02215"]},
-    "contacts":[{"name":"General Inquiries","phone":"617-353-4301","fax":"617-353-4307","email":"pardstf@bu.edu"},{"name":"Reference","phone":"617-353-4304","email":"pardstf@bu.edu"},{"name":"Circulation","phone":"617-353-4301","email":"pardedoc@bu.edu"},{"name":"Reserves","phone":"617-353-4301","email":"pardres@bu.edu"}],
+    "address":["595 Commonwealth Avenue","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-4301","fax":"617-353-4307","email":"pardstf@bu.edu"},
     "social":{"twitter":"BUpardeelibrary","facebook":"pardeelibrary"}
   },"pickering":{
+    "name":"Pickering Educational Resources Library",
     "website":"https://www.bu.edu/library/pickering-educational/",
-    "location":{"address":["Pickering Educational Resources Library","2 Silber Way","Boston, MA 02215"]},
-    "contacts":[{"name":"General Inquiries","phone":"617-353-3734"}],
+    "address":["2 Silber Way","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3734"},
     "social":{"twitter":"BUPickeringLib","facebook":"BUPickeringLibrary"}
   },"sel":{
+    "name":"Science & Engineering Library",
     "website":"https://www.bu.edu/library/sel/",
-    "location":{"address":["Science & Engineering Library","38 Cummington Mall","Boston, MA 02215"]},
-    "contacts":[{"name":"General Inquiries","phone":"617-353-3733","fax":"617-353-3470"},{"name":"Library Hours","phone":"617-358-4125"},{"name":"Reference","phone":"617-353-9454","email":"ask@bu.edu"},{"name":"Circulation","phone":"617-353-3733","email":"selcirc@bu.edu"},{"name":"Reserves","phone":"617-353-3733","email":"selresrv@bu.edu"}],
+    "address":["38 Cummington Mall","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3733","fax":"617-353-3470"},
     "social":{"twitter":"BUSciEngLib","tumblr":"buscienglib","instagram":"buscienglib"}
   },"stone":{
+    "name":"Stone Science Library",
     "website":"https://www.bu.edu/library/stone-science/",
-    "location":{"address":["Stone Science Library","675 Commonwealth Ave, Floor 2","Boston, MA 02445"]},
-    "contacts":[{"name":"General Inquiries","phone":"617-353-5679"}]
+    "address":["675 Commonwealth Ave, Floor 2","Boston, MA 02445"],
+    "contacts":{"phone":"617-353-5679"}
   },"theology":{
+    "name":"School of Theology Library",
     "website":"https://www.bu.edu/sthlibrary/",
-    "location":{"address":["School of Theology Library","745 Commonwealth Ave, Floor 2","Boston, MA 02215"]},
-    "contacts":[{"name":"General Inquiries","phone":"617-353-3034","fax":"617-358-0698","email":"sthlib@bu.edu"},{"name":"Reference","phone":"617-353-3034","email":"sthref@bu.edu"}],
+    "address":["745 Commonwealth Ave, Floor 2","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-3034","fax":"617-358-0698","email":"sthlib@bu.edu"},
     "social":{"twitter":"BUSTHLibrary","facebook":"busthlibrary","instagram":"butheologylibrary"}
   },"help":{
+    "name":"BU Libraries",
     "website":"https://askalibrarian.bu.edu/",
-    "location":{"address":["BU Libraries","771 Commonwealth Avenue","Boston, MA 02215"]},
-    "contacts":[{"name":"help","phone":"617-353-2700","email":"ask@bu.edu","text":"617-431-2427"}],
+    "address":["771 Commonwealth Avenue","Boston, MA 02215"],
+    "contacts":{"phone":"617-353-2700","email":"ask@bu.edu","text":"617-431-2427"},
     "social":{"twitter":"BULibNews"}
   }
 };
@@ -90,20 +103,25 @@ class BULocoso extends LitElement {
 
   render() {
     let myLocoso = locoso[this.library] || locoso["mugar-memorial"];
-    if(debug){ console.log("bulib-locoso) myLocoso: ") + console.log(myLocoso); }
+    if(debug){ console.log("bulib-locoso) myLocoso: "); console.log(myLocoso); }
 
-    this.contacts = this._prepareContacts(myLocoso["contacts"][0] || {});
-    this.address = myLocoso["location"]["address"] || [];
-    this.social = this._prepareSocial(myLocoso["social"] || {});
-    this.website = myLocoso["website"] || "https://www.bu.edu/library/about";
+    let lib_name = myLocoso["name"] || "BU Libraries";
+    let address = myLocoso["address"] || ["771 Commonwealth Avenue","Boston, MA 02215"];
+    let website = myLocoso["website"] || "https://www.bu.edu/library/about";
+
+    let raw_contacts = myLocoso["contacts"] || {"phone":"617-353-2700","email":"ask@bu.edu","text":"617-431-2427"};
+    let contacts = this._prepareContacts(raw_contacts);
+    
+    let raw_social = myLocoso["social"] || {};
+    let social = this._prepareSocial(raw_social);
     
     let socialDisplay;
-    if(this.social.length < 1){ socialDisplay = html``; }
+    if(social.length < 1){ socialDisplay = html``; }
     else{
       socialDisplay= html`
         <h3>Follow Us</h3>
         <ul aria-description="list of social media accounts" class="no-bullet inline-list plm">
-        ${this.social.map((s) =>
+        ${social.map((s) =>
           html`<li><a class="${this.link_class}" target="_blank" href="${s.url}" title="${s.text}"><img alt="${s.text} icon" class="sm-icon ${this.link_class}"
                       src="https://raw.githubusercontent.com/bulib/bulib-wc/master/assets/icons/icons8-${s.text}-48.png"></a></li>`
         )}
@@ -133,12 +151,13 @@ class BULocoso extends LitElement {
         <div class="left prm">
           <h3 class="inline">Visit Us</h3>&nbsp;
           <ol class="no-bullet" aria-label="address">
-            ${this.address.map((l) => html`<li>${l}</li>`)}
+            <li>${lib_name}</li>
+            ${address.map((l) => html`<li>${l}</li>`)}
             <li>
               <small>
-                <a class="${this.link_class}" aria-label="Open library site" href="${this.website}" title="${this.address[0]}"">website</a>
+                <a class="${this.link_class}" aria-label="Open library site" href="${website}" title="${lib_name} website">website</a>
                 <a class="${this.link_class}" aria-label="Directions to the Library" title="get directions" target="_blank"
-                    href="${'https://google.com/maps/search/' + encodeURI("Boston University " + this.address[0])}">directions &raquo;</a>
+                    href="${'https://google.com/maps/search/' + encodeURI("Boston University " + lib_name)}">directions &raquo;</a>
               </small>
             </li>
           </ol>
@@ -146,7 +165,7 @@ class BULocoso extends LitElement {
         <div>
           <h3 class="inline">Contact Us</h3>
           <ul class="no-bullet" aria-label="contact-links">
-            ${this.contacts.map((c) =>
+            ${contacts.map((c) =>
                 html`<li>${c.text} <a class="${this.link_class}" href="${c.url}">${c.val}</a></li>`
              )}
           </ul>
@@ -158,6 +177,8 @@ class BULocoso extends LitElement {
 
   /** use the raw 'contacts' data to populate a basic list that can more easily displayed as a list of links */
   _prepareContacts(rawContacts){
+    if(Object.keys(rawContacts).length < 1){ return {}; }
+    
     let contacts = [];
     if(rawContacts["phone"]){
       contacts.push( {"text":"call", "url":"tel:"+rawContacts["phone"], "val":rawContacts["phone"]} );
@@ -176,6 +197,8 @@ class BULocoso extends LitElement {
 
   /** use raw 'social' data to generate a list of basic profile links for easy display */
   _prepareSocial(rawSocial){
+    if(Object.keys(rawSocial).length < 1){ return []; }
+    
     let social = [];
     if(rawSocial["twitter"]){
       social.push( {"text":"twitter", "url":"http://twitter.com/"+rawSocial["twitter"]} );

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -1,85 +1,7 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
 
 const debug = false;
-
-/** static LOcation, COntact, SOcial data used by the element */
-const locoso = {
-  "mugar-memorial":{
-    "name":"Mugar Memorial Library",
-    "website":"https://www.bu.edu/library/mugar-memorial/",
-    "address":["771 Commonwealth Avenue","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-2700","email":"ask@bu.edu"},
-    "social":{"facebook":"mugarlib","twitter":"mugarlib","instagram":"mugarlib"}
-  },"african-studies":{
-    "name":"African Studies Library",
-    "website":"https://www.bu.edu/library/african-studies/",
-    "address":["771 Commonwealth Ave, 6th Floor","Boston, MA, 02215"],
-    "contacts":{"phone":"617-353-3726"},
-    "social":{"facebook":"BuAfricanStudiesLibrary","flickr":"123460528@N03"}
-  },"medlib":{
-    "name":"Alumni Medical Library",
-    "website":"https://medlib.bu.edu/",
-    "address":["72 E Concord, L-12","Boston, MA 02118"],
-    "contacts":{"phone":"617-358-2350","fax":"617-358-2347","email":"refquest@bu.edu"},
-  },"astronomy":{
-    "name":"Astronomy Library",
-    "website":"https://www.bu.edu/library/astronomy/",
-    "address":["725 Commonwealth Avenue","Boston, MA 02445"],
-    "contacts":{"phone":"617-353-2625"}
-  },"lawlibrary":{
-    "name":"Fineman & Pappas Law Libraries",
-    "website":"https://www.bu.edu/lawlibrary/",
-    "address":["765 Commonwealth Ave, 2nd Floor","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-8411","text":"1-617-997-4475"}
-  },"hgar":{
-    "name":"Howard Gotlieb Archival Research Center",
-    "website":"http://archives.bu.edu/",
-    "address":["771 Commonwealth Ave, 5th Floor","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-3696","fax":"617-353-2838","email":"archives@bu.edu"},
-    "social":{"facebook":"hgarc","twitter":"BUHGARC"}
-  },"music":{
-    "name":"Music Library",
-    "website":"https://www.bu.edu/library/music/",
-    "address":["771 Commonwealth Ave, Floor 2","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-3705","email":"musiclib@bu.edu"},
-    "social":{"twitter":"BUMusicLib","facebook":"bumusiclib"}
-  },"pardee":{
-    "name":"Pardee Management Library",
-    "website":"https://www.bu.edu/library/management/",
-    "address":["595 Commonwealth Avenue","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-4301","fax":"617-353-4307","email":"pardstf@bu.edu"},
-    "social":{"twitter":"BUpardeelibrary","facebook":"pardeelibrary"}
-  },"pickering":{
-    "name":"Pickering Educational Resources Library",
-    "website":"https://www.bu.edu/library/pickering-educational/",
-    "address":["2 Silber Way","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-3734"},
-    "social":{"twitter":"BUPickeringLib","facebook":"BUPickeringLibrary"}
-  },"sel":{
-    "name":"Science & Engineering Library",
-    "website":"https://www.bu.edu/library/sel/",
-    "address":["38 Cummington Mall","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-3733","fax":"617-353-3470"},
-    "social":{"twitter":"BUSciEngLib","tumblr":"buscienglib","instagram":"buscienglib"}
-  },"stone":{
-    "name":"Stone Science Library",
-    "website":"https://www.bu.edu/library/stone-science/",
-    "address":["675 Commonwealth Ave, Floor 2","Boston, MA 02445"],
-    "contacts":{"phone":"617-353-5679"}
-  },"theology":{
-    "name":"School of Theology Library",
-    "website":"https://www.bu.edu/sthlibrary/",
-    "address":["745 Commonwealth Ave, Floor 2","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-3034","fax":"617-358-0698","email":"sthlib@bu.edu"},
-    "social":{"twitter":"BUSTHLibrary","facebook":"busthlibrary","instagram":"butheologylibrary"}
-  },"help":{
-    "name":"BU Libraries",
-    "website":"https://askalibrarian.bu.edu/",
-    "address":["771 Commonwealth Avenue","Boston, MA 02215"],
-    "contacts":{"phone":"617-353-2700","email":"ask@bu.edu","text":"617-431-2427"},
-    "social":{"twitter":"BULibNews"}
-  }
-};
 
 /**
  * display the *LO*cation, *CO*ntact, and *SO*cial media information for
@@ -102,7 +24,7 @@ class BULocoso extends LitElement {
   }
 
   render() {
-    let myLocoso = locoso[this.library] || locoso["mugar-memorial"];
+    let myLocoso = getLibraryInfoFromCode(this.library) || {};
     if(debug){ console.log("bulib-locoso) myLocoso: "); console.log(myLocoso); }
 
     let lib_name = myLocoso["name"] || "BU Libraries";


### PR DESCRIPTION
### Description of Changes
- pull `library_data` out of `locoso` element to allow for reuse in `header`, `libsel`, and `select`
- create a new `_helpers/` directory to hold any reusable `lib_info_helper`-related methods 