### PR TITLE
footer: cross-browser styling fixes

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1,5 +1,6 @@
 /* -- padding and alignment -- */
 .pam { padding: 10px; }
+.pvm { padding: 10px 0px; }
 .ptl { padding-top: 15px; }
 .left { float: left; }
 .txtc { text-align: center; }

--- a/src/footer/footer.css
+++ b/src/footer/footer.css
@@ -55,4 +55,4 @@ footer {
 
 /* etc */
 .bu-logo { padding-right: 25px; }
-#sitemap > h3 { font-size: 130%; }
+#sitemap > h3, #sitemap > * > h3 { font-size: 130%; }

--- a/src/footer/footer.css
+++ b/src/footer/footer.css
@@ -55,4 +55,4 @@ footer {
 
 /* etc */
 .bu-logo { padding-right: 25px; }
-#sitemap { font-size: 130%; }
+#sitemap > h3 { font-size: 130%; }

--- a/src/footer/footer.css
+++ b/src/footer/footer.css
@@ -51,5 +51,4 @@ footer {
 
 /* etc */
 .bu-logo { padding-right: 25px; }
-bulib-footer > * > h3 { margin-top: 0px; margin-bottom: 0px; color: white; text-align: center; }
 bulib-footer > * > ul, bulib-footr > * > ol { margin-top: 5px; margin-bottom: 5px; }

--- a/src/footer/footer.css
+++ b/src/footer/footer.css
@@ -33,6 +33,10 @@ footer {
   }
   .ftr-middle { border-bottom: solid transparent 1px !important; }
   .ftr-right  { border-bottom: solid transparent 1px !important; }
+  #sitemap { 
+    width: 80%; 
+    margin: 0 auto; 
+  }
 }
 
 /* on super large screens, set the width to 80% to avoid getting too much spacing */
@@ -51,3 +55,4 @@ footer {
 
 /* etc */
 .bu-logo { padding-right: 25px; }
+#sitemap { font-size: 130%; }

--- a/src/footer/footer.css
+++ b/src/footer/footer.css
@@ -51,4 +51,3 @@ footer {
 
 /* etc */
 .bu-logo { padding-right: 25px; }
-bulib-footer > * > ul, bulib-footr > * > ol { margin-top: 5px; margin-bottom: 5px; }

--- a/src/footer/footer.html
+++ b/src/footer/footer.html
@@ -17,7 +17,7 @@
   </head>
   <body>
     <bulib-footer>
-      <strong slot="sitemap">this is the custom footer text</strong>
+      <h3 slot="sitemap">this is the custom footer text</h3>
     </bulib-footer>
     <br /><hr /><br />
     <bulib-select

--- a/src/footer/footer.html
+++ b/src/footer/footer.html
@@ -16,13 +16,16 @@
     <script src="../select/select.js" type="module"></script>
   </head>
   <body>
-    <bulib-footer>
-      <h3 slot="sitemap">this is the custom footer text</h3>
-    </bulib-footer>
+    <bulib-footer host_site="askalibrarian"></bulib-footer>
     <br /><hr /><br />
     <bulib-select
       sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"
       tag_name="bulib-footer" attr_name="library">
-      </bulib-select>
+    </bulib-select>
+    <br /><br />
+    <bulib-select
+      sel_title="Select Site" curr_sel="help" opt_code="sites"
+      tag_name="bulib-footer" attr_name="host_site">
+    </bulib-select>
   </body>
 </html>

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -94,8 +94,8 @@ class BULFooter extends LitElement {
     
     // render the 
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/assets/css/common.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.css">
       <style>
         /* firefox fix to stop the 'Follow Us' from becoming centered */
         ::slotted(h3) { text-align: left; }

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -119,13 +119,14 @@ class BULFooter extends LitElement {
             </div>
           </div>
           <div class="ftr-middle">
-            <div><slot id="sitemap" name="sitemap">${sitemap_content}</slot></div>
+            <div id="sitemap"><slot name="sitemap">${sitemap_content}</slot></div>
           </div>
           <div class="ftr-right">
             <div><bulib-locoso library="${this.library}" link_class="white-link"></bulib-locoso></div>
           </div>
         </footer>
-      </div>`;
+      </div>
+    `;
   }
 
 }

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -52,13 +52,16 @@ class BULFooter extends LitElement {
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.css">
       <style>
         /* set top and bottom margins, font size, and color for all h3s */
-        :slotted(h3), :hosted(h3), h3 { margin-top: 0px; margin-bottom: 0px; font-size: 150%; color: white; }
+        h3, :slotted(h3) { 
+          margin-top: 0px; 
+          margin-bottom: 0px; 
+          font-size: 150%; 
+          text-align: center;
+          color: white !important; 
+        }
         
         /* prevent host from setting the left-right margins, add top-bottom margins*/
-        ul, ol, :slotted(ul), :hosted(ol) { margin: 5px 0px !important; }
-        
-        /* resolve wordpress-oriented oddities */
-        :slotted(li), :hosted(li), li { background: none; }
+        ul, ol, :slotted(ul), :slotted(ol) { margin: 5px 0px !important; }
       </style>
       <div class="footer-wrapper">
       <footer class="pam">

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -3,6 +3,39 @@ import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/li
 const debug = true;
 const local = false;
 
+/** stored values for the sitemap */
+const sitemap_values = {
+  "wordpress":{
+    "header":"Boston University Libraries",
+    "links":[
+      {"title":"InterLibrary Borrowing","href":"/library/services/ill/"},
+      {"title":"Course Reserves",       "href":"/library/services/reserves/"},
+      {"title":"For Alumni",            "href":"/library/services/alumni/"},
+      {"title":"Staff Directory",       "href":"/library/about/who-we-are/staff-directory/"},
+      {"title":"Maps & Floorplans",     "href":"/library/about/maps-floorplans/"},
+      {"title":"For Faculty",           "href":"/library/services/for-faculty/"}
+    ]
+  },"askalibrarian":{
+    "header":"Ask A Librarian",
+    "links":[
+      {"title":"Research Guides by Subject",    "href":"/guides"},
+      {"title":"Course Guides",                 "href":"https://www.bu.edu/library/research/guides/course-guides/"},
+      {"title":"How-To Guides",                 "href":"https://www.bu.edu/library/help/how-to/"},
+      {"title":"Pardee Management Library FAQs","href":"/businessFAQs/"},
+      {"title":"Make a Research Appointment",   "href":"https://www.bu.edu/library/services/reference/appointments/"}
+    ]
+  },"guides":{
+    "header":"Library Guides",
+    "links":[
+      {"title":"Research Guides by Subject",  "href":"/guides"},
+      {"title":"Course Guides",               "href":"https://www.bu.edu/library/research/guides/course-guides/"},
+      {"title":"How-To Guides",               "href":"https://www.bu.edu/library/help/how-to/"},
+      {"title":"Make a Research Appointment", "href":"https://www.bu.edu/library/services/reference/appointments/"},
+      {"title":"Library Locations",           "href":"http://www.bu.edu/library/about/"}
+    ]
+  }
+};
+
 /** Reactive/responsive footer providing slotted middle section and customizable LoCoSo data */
 class BULFooter extends LitElement {
 
@@ -14,7 +47,9 @@ class BULFooter extends LitElement {
   static get properties() {
     return {
       /** provide window into setting displayed 'locoso' contact data */
-      library: {type: String, notify:true}
+      library: {type: String, notify:true},
+      /** key for the subsite (used to populate the sitemap) */
+      host_site: {type: String}
     };
   }
   
@@ -47,49 +82,49 @@ class BULFooter extends LitElement {
   }
 
   render() {
+    // fill in the sitemap middle section of the footer
+    let sitemap_data = sitemap_values[this.host_site] || sitemap_values["askalibrarian"];
+    let links = sitemap_data["links"]; 
+    let sitemap_content = html`
+      <h3 class="txtc">${sitemap_data["header"]}</h3>
+      <ul class="multi-column no-bullet">
+        ${links.map((l) => html`<li><a class="white-link pvm" href="${l.href}">${l.title}</a></li>`)}
+      </ul>
+    `;
+    
+    // render the 
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.5/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.3/src/footer/footer.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.4/assets/css/common.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.4/src/footer/footer.css">
       <style>
-        /* set top and bottom margins, font size, and color for all h3s */
-        h3, ::slotted(h3) { 
-          font-size: 135%; 
-          text-align: center !important;
-          color: white !important; 
-        }
-        
-        /* prevent host from setting the left-right margins, add top-bottom margins*/
-        ul, ol, ::slotted(ul), ::slotted(ol) { 
-          margin: 5px 0px; 
-        }
+        /* firefox fix to stop the 'Follow Us' from becoming centered */
+        ::slotted(h3) { text-align: left; }
       </style>
       <div class="footer-wrapper">
-      <footer class="pam">
-        <div class="ftr-left">
-          <div id="bu-content">
-            <div class="left txtc bu-logo">
-              <br />
-              <a href="https://www.bu.edu/" title="Boston University Home"><img alt="boston university logo" src="http://www.bu.edu/academics/files/bu-logo.gif"></a>
-              <br /><br />
-              <small><a class="white-link" href="https://www.bu.edu/copyright" title="Copyright">&copy; Copyright ${new Date().getFullYear()}</a></small>
-              <br /><br />
-            </div>
-            <div>
-              <ul class="no-bullet ptl">
-                <li><a class="white-link" href="https://www.bu.edu/library/" title="Libraries Home">Libraries Home</a></li>
-                <li><a class="white-link" href="http://bu.edu/library/search" title="Search available/licensed content">Libraries Search</a></li>
-                <li><a class="white-link" href="https://askalibrarian.bu.edu/" title="Help">Help</a></li>
-              </ul>
+        <footer class="pam">
+          <div class="ftr-left">
+            <div id="bu-content">
+              <div class="left txtc bu-logo">
+                <br />
+                <a href="https://www.bu.edu/" title="Boston University Home"><img alt="boston university logo" src="http://www.bu.edu/academics/files/bu-logo.gif"></a>
+                <br /><br />
+                <small><a class="white-link" href="https://www.bu.edu/copyright" title="Copyright">&copy; Copyright ${new Date().getFullYear()}</a></small>
+                <br /><br />
+              </div>
+                <ul class="no-bullet ptl">
+                  <li><a class="white-link" href="https://www.bu.edu/library/" title="Libraries Home">Libraries Home</a></li>
+                  <li><a class="white-link" href="http://bu.edu/library/search" title="Search available/licensed content">Libraries Search</a></li>
+                  <li><a class="white-link" href="https://askalibrarian.bu.edu/" title="Help">Help</a></li>
+                </ul>
             </div>
           </div>
-        </div>
-        <div class="ftr-middle">
-          <div><slot id="sitemap" name="sitemap"></slot></div>
-        </div>
-        <div class="ftr-right">
-          <div><bulib-locoso library="${this.library}" link_class="white-link"></bulib-locoso></div>
-        </div>
-      </footer>
+          <div class="ftr-middle">
+            <div><slot id="sitemap" name="sitemap">${sitemap_content}</slot></div>
+          </div>
+          <div class="ftr-right">
+            <div><bulib-locoso library="${this.library}" link_class="white-link"></bulib-locoso></div>
+          </div>
+        </footer>
       </div>`;
   }
 

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -49,19 +49,21 @@ class BULFooter extends LitElement {
   render() {
     return html`
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.5/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.3/src/footer/footer.css">
       <style>
         /* set top and bottom margins, font size, and color for all h3s */
-        h3, :slotted(h3) { 
-          margin-top: 0px; 
+        h3, ::slotted(h3) { 
+          margin-top: 0px;
           margin-bottom: 0px; 
           font-size: 150%; 
-          text-align: center;
+          text-align: center !important;
           color: white !important; 
         }
         
         /* prevent host from setting the left-right margins, add top-bottom margins*/
-        ul, ol, :slotted(ul), :slotted(ol) { margin: 5px 0px !important; }
+        ul, ol, ::slotted(ul), ::slotted(ol) { 
+          margin: 5px 0px; 
+        }
       </style>
       <div class="footer-wrapper">
       <footer class="pam">

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -51,8 +51,14 @@ class BULFooter extends LitElement {
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.5/assets/css/common.min.css">
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.css">
       <style>
-        :host(h3), h3 { margin-top: 0px; margin-bottom: 0px; }
-        ul, ol { margin-top: 5px; margin-bottom: 5px; }
+        /* set top and bottom margins, font size, and color for all h3s */
+        :slotted(h3), :hosted(h3), h3 { margin-top: 0px; margin-bottom: 0px; font-size: 150%; color: white; }
+        
+        /* prevent host from setting the left-right margins, add top-bottom margins*/
+        ul, ol, :slotted(ul), :hosted(ol) { margin: 5px 0px !important; }
+        
+        /* resolve wordpress-oriented oddities */
+        :slotted(li), :hosted(li), li { background: none; }
       </style>
       <div class="footer-wrapper">
       <footer class="pam">

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -53,9 +53,7 @@ class BULFooter extends LitElement {
       <style>
         /* set top and bottom margins, font size, and color for all h3s */
         h3, ::slotted(h3) { 
-          margin-top: 0px;
-          margin-bottom: 0px; 
-          font-size: 150%; 
+          font-size: 135%; 
           text-align: center !important;
           color: white !important; 
         }
@@ -74,6 +72,7 @@ class BULFooter extends LitElement {
               <a href="https://www.bu.edu/" title="Boston University Home"><img alt="boston university logo" src="http://www.bu.edu/academics/files/bu-logo.gif"></a>
               <br /><br />
               <small><a class="white-link" href="https://www.bu.edu/copyright" title="Copyright">&copy; Copyright ${new Date().getFullYear()}</a></small>
+              <br /><br />
             </div>
             <div>
               <ul class="no-bullet ptl">

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -94,8 +94,8 @@ class BULFooter extends LitElement {
     
     // render the 
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.4/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.4/src/footer/footer.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.css">
       <style>
         /* firefox fix to stop the 'Follow Us' from becoming centered */
         ::slotted(h3) { text-align: left; }

--- a/src/footer/usages/_footer-includes.html
+++ b/src/footer/usages/_footer-includes.html
@@ -2,9 +2,9 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>

--- a/src/footer/usages/_footer-includes.html
+++ b/src/footer/usages/_footer-includes.html
@@ -2,9 +2,9 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.js" type="module"></script>

--- a/src/footer/usages/libanswers-footer.html
+++ b/src/footer/usages/libanswers-footer.html
@@ -4,12 +4,12 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.js" type="module"></script>
 
 <div class="container">
   <bulib-footer library="help" host_site="askalibrarian"></bulib-footer>

--- a/src/footer/usages/libanswers-footer.html
+++ b/src/footer/usages/libanswers-footer.html
@@ -4,12 +4,12 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
 
 <div class="container">
   <bulib-footer library="help" host_site="askalibrarian"></bulib-footer>

--- a/src/footer/usages/libanswers-footer.html
+++ b/src/footer/usages/libanswers-footer.html
@@ -12,17 +12,5 @@
 <script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.js" type="module"></script>
 
 <div class="container">
-  <!-- note: defaulted library code (for locoso) should be adjusted according to subsite) -->
-  <bulib-footer library="help">
-    <div slot="sitemap" id="sitemap">
-      <h3>Ask a Librarian</h3>
-      <ul class="multi-column no-bullet">
-        <li><a class="white-link" href="https://library.bu.edu/guides">Research Guides by Subject</a></li>
-        <li><a class="white-link" href="https://www.bu.edu/library/research/guides/course-guides/">Course Guides</a></li>
-        <li><a class="white-link" href="https://www.bu.edu/library/help/how-to/">How-To Guides</a></li>
-        <li><a class="white-link" href="https://askalibrarian.bu.edu/businessFAQs/">Pardee Management Library FAQs</a></li>
-        <li><a class="white-link" href="https://www.bu.edu/library/services/reference/appointments/">Make a Research Appointment</a></li>
-      </ul>
-    </div>
-  </bulib-footer>
+  <bulib-footer library="help" host_site="askalibrarian"></bulib-footer>
 </div>

--- a/src/footer/usages/libguides-footer.html
+++ b/src/footer/usages/libguides-footer.html
@@ -4,12 +4,12 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
 
 <style type="text/css">
   /* style the 'Powered by Springshare' band 'Login to LibApps' link */

--- a/src/footer/usages/libguides-footer.html
+++ b/src/footer/usages/libguides-footer.html
@@ -26,15 +26,4 @@
   }
 </style>
 
-<bulib-footer library="help">
-  <div slot="sitemap" id="sitemap">
-    <h3>Library Guides</h3>
-    <ul class="multi-column no-bullet">
-      <li><a class="white-link" href="https://library.bu.edu/guides">Research Guides by Subject</a></li>
-      <li><a class="white-link" href="https://www.bu.edu/library/research/guides/course-guides/">Course Guides</a></li>
-      <li><a class="white-link" href="https://www.bu.edu/library/help/how-to/">How-To Guides</a></li>
-      <li><a class="white-link" href="https://www.bu.edu/library/services/reference/appointments/">Make a Research Appointment</a></li>
-      <li><a class="white-link" href="http://www.bu.edu/library/about/">Library Locations</a></li>
-    </ul>
-  </div>
-</bulib-footer>
+<bulib-footer library="help" host_site="guides"></bulib-footer>

--- a/src/footer/usages/libguides-footer.html
+++ b/src/footer/usages/libguides-footer.html
@@ -4,12 +4,12 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.js" type="module"></script>
 
 <style type="text/css">
   /* style the 'Powered by Springshare' band 'Login to LibApps' link */

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -23,16 +23,4 @@
   #sitemap > ul li, ol li { background: none; }
 </style>
 
-<bulib-footer library="mugar-memorial">
-  <div slot="sitemap" id="sitemap">
-    <h3>Boston University Libraries</h3>
-    <ul class="multi-column no-bullet">
-      <li><a class="white-link" href="/library/services/ill/">InterLibrary Borrowing</a></li>
-      <li><a class="white-link" href="/library/services/reserves/">Course Reserves</a></li>
-      <li><a class="white-link" href="/library/services/alumni/">For Alumni</a></li>
-      <li><a class="white-link" href="/library/about/who-we-are/staff-directory/">Staff Directory</a></li>
-      <li><a class="white-link" href="/library/about/maps-floorplans/">Maps &amp; Floorplans</a></li>
-      <li><a class="white-link" href="/library/services/for-faculty/">For Faculty</a></li>
-    </ul>
-  </div>
-</bulib-footer>
+<bulib-footer library="mugar-memorial" host_site="wordpress"></bulib-footer>

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -4,18 +4,18 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.js" type="module"></script>
 
 <style>
   /* hide BU Logo and 'Libraries & Archives' heading */
   #footer-logo-container, #footer-content > h2 { display: none; }
 
-  /* prevent overflow of footer width to 900px on small screens */
+  /* prevent overflow of footer width to 900px on small screensq */
   #footer > div.container { width: auto; }
   #footer-content { float: inherit; }
   

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -19,8 +19,13 @@
   #footer > div.container { width: auto; }
   #footer-content { float: inherit; }
   
-  /* remove strange list bullet styling (green dot with white background) */
-  #sitemap > ul li, ol li { background: none; }
+  /* firefox-specific adjustments for text color, link background, margins */
+  h3.style-scope.bulib-footer { color: white; }
+  li.style-scope.bulib-footer { 
+    background-image: none; 
+    color: white;
+    margin: unset;
+}
 </style>
 
 <bulib-footer library="mugar-memorial" host_site="wordpress"></bulib-footer>

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -4,12 +4,12 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v1.7/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.1.5/src/footer/footer.min.js" type="module"></script>
 
 <style>
   /* hide BU Logo and 'Libraries & Archives' heading */

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -20,7 +20,7 @@
   #footer-content { float: inherit; }
   
   /* remove strange list bullet styling (green dot with white background) */
-  #sitemap > ul li { background-image: none; }
+  #sitemap > ul li, ol li { background: none; }
 </style>
 
 <bulib-footer library="mugar-memorial">

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -121,7 +121,7 @@ class BULocoso extends LitElement {
         }
 
         /* list styles, */
-        ul, ol { margin-top: 5px; margin-bottom: 5px; padding-left: 0; }
+        ul, ol { margin: 5px 0px; padding-left: 0; }
 
         /* padding and margins */
         h3 { margin-top: 0px; margin-bottom: 0px; }

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -101,7 +101,7 @@ class BULocoso extends LitElement {
     if(this.social.length < 1){ socialDisplay = html``; }
     else{
       socialDisplay= html`
-        <h3>Follow Us</h3>
+        <h3 class="left">Follow Us</h3><br />
         <ul aria-description="list of social media accounts" class="no-bullet inline-list plm">
         ${this.social.map((s) =>
           html`<li><a class="${this.link_class}" target="_blank" href="${s.url}" title="${s.text}"><img alt="${s.text} icon" class="sm-icon ${this.link_class}"
@@ -121,10 +121,10 @@ class BULocoso extends LitElement {
         }
 
         /* list styles, */
-        ul, ol { margin: 5px 0px; padding-left: 0; }
+        ul, ol { margin: 5px 0px; padding-left: 0; padding-bottom: 10px; }
 
         /* padding and margins */
-        h3 { margin-top: 0px; margin-bottom: 0px; }
+        h3 { margin-top: 0px; margin-bottom: 0px; text-align: left !important; }
         .prm { margin-right: 10px; padding-right: 10px; }
         .sm-icon { width: 30px; height: 30px; border: solid transparent 1px; }
         .sm-icon:hover { width: 30px; height: 30px; border: solid white 1px; }

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -101,7 +101,7 @@ class BULocoso extends LitElement {
     if(this.social.length < 1){ socialDisplay = html``; }
     else{
       socialDisplay= html`
-        <h3 class="left">Follow Us</h3><br />
+        <h3>Follow Us</h3>
         <ul aria-description="list of social media accounts" class="no-bullet inline-list plm">
         ${this.social.map((s) =>
           html`<li><a class="${this.link_class}" target="_blank" href="${s.url}" title="${s.text}"><img alt="${s.text} icon" class="sm-icon ${this.link_class}"
@@ -124,7 +124,7 @@ class BULocoso extends LitElement {
         ul, ol { margin: 5px 0px; padding-left: 0; padding-bottom: 10px; }
 
         /* padding and margins */
-        h3 { margin-top: 0px; margin-bottom: 0px; text-align: left !important; }
+        #locoso > div > h3 { margin-top: 0px; margin-bottom: 0px; text-align: }
         .prm { margin-right: 10px; padding-right: 10px; }
         .sm-icon { width: 30px; height: 30px; border: solid transparent 1px; }
         .sm-icon:hover { width: 30px; height: 30px; border: solid white 1px; }

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -25,9 +25,16 @@ const wp_urls = [
   {"name":"African Studies","value":"https://www.bu.edu/library/african-studies/", },
   {"name":"Help",           "value":"askalibrarian.bu.edu/"}
 ];
+const sites = [
+  {"name":"SELECT A SITE",  "value":"askalibrarian"},
+  {"name":"Ask a Librarian","value":"askalibrarian"},
+  {"name":"LibGuides",      "value":"guides"},
+  {"name":"Wordpress",      "value":"wordpress"}
+];
 const opt_map = {
   "libraries":libraries,
-  "wp_urls":wp_urls
+  "wp_urls":wp_urls,
+  "sites":sites
 };
 
 class BULSelect extends LitElement{


### PR DESCRIPTION
### Description
- firefox and wordpress both do some weird things to the output, so i (mostly) fixed those
- slot added some unnecessary complexity, so i gutted that out and now it just switches between local data. will likely do the same thing with `bulib-header` later on. 