### PR TITLE
WEB-36: Windows Browser Compatibility (stop-gap)

### DIFF
--- a/src/_helpers/browser_compatibility.js
+++ b/src/_helpers/browser_compatibility.js
@@ -21,7 +21,7 @@ var loadWebComponentInto = function(tagname, replacedElements){
   
   // do the hiding
   for(var i=0; i<elementsToHide.length; i++){
-    elementsToHide[i].style.visibility = "hidden";
+    elementsToHide[i].hidden = true;
   }
   
   // log the result

--- a/src/_helpers/browser_compatibility.js
+++ b/src/_helpers/browser_compatibility.js
@@ -1,3 +1,5 @@
+var debug = true;
+
 var doesBrowserSupportWebComponents = function(){
   /** determine the browser the code is being run on
    * note: thanks to [stackoverflow](https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser/9851769) for the implementation
@@ -8,21 +10,23 @@ var doesBrowserSupportWebComponents = function(){
   return user_agent_supports_web_components;
 };
 
-var loadWebComponentInto = function(tagname, replacedElement){
+var loadWebComponentInto = function(tagname, replacedElements){
   var user_agent_supports_web_components = doesBrowserSupportWebComponents();
-  if(user_agent_supports_web_components){
-    // show the component and hide its replacement
-    console.log("user_agent_supports_web_components! :)");
-    replacedElement.style.visibility = "hidden";
-  }else{
-    // hide the component itself
-    console.log("!user_agent_supports_web_components. :(");
-    console.log(tagname);
-    var lsElements = document.getElementsByTagName(tagname);
-    console.log(lsElements);
-    for(var i=0; i<lsElements.length; i++){
-      lsElements[i].style.visibility = "hidden";
-    }
+  
+  // determine which elements to hide
+  var elementsToHide = user_agent_supports_web_components 
+    ? replacedElements // hide replaced elements if the web components worked,
+    : document.getElementsByTagName(tagname) // hide the contents of the custom tag if they don't (avoid showing 'slotted' coni)
+  ; 
+  
+  // do the hiding
+  for(var i=0; i<elementsToHide.length; i++){
+    elementsToHide[i].style.visibility = "hidden";
+  }
+  
+  // log the result
+  if(debug){
+    var supportsMessage = user_agent_supports_web_components ? ": ]" : ":(";
+    console.log("user_agent_supports_web_components: " + supportsMessage);
   }
 };
-module.exports = { loadWebComponentInto:loadWebComponentInto };

--- a/src/_helpers/browser_compatibility.js
+++ b/src/_helpers/browser_compatibility.js
@@ -25,4 +25,4 @@ var loadWebComponentInto = function(tagname, replacedElement){
     }
   }
 };
-module.exports = { loadWebComponentInto };
+module.exports = { loadWebComponentInto:loadWebComponentInto };

--- a/src/_helpers/browser_compatibility.js
+++ b/src/_helpers/browser_compatibility.js
@@ -25,3 +25,4 @@ var loadWebComponentInto = function(tagname, replacedElement){
     }
   }
 };
+module.exports = { loadWebComponentInto };

--- a/src/_helpers/browser_compatibility.js
+++ b/src/_helpers/browser_compatibility.js
@@ -20,9 +20,7 @@ var loadWebComponentInto = function(tagname, replacedElements){
   ; 
   
   // do the hiding
-  for(var i=0; i<elementsToHide.length; i++){
-    elementsToHide[i].hidden = true;
-  }
+  for(var i=0; i<elementsToHide.length; i++){ elementsToHide[i].hidden = true; }
   
   // log the result
   if(debug){

--- a/src/_helpers/browser_compatibility.js
+++ b/src/_helpers/browser_compatibility.js
@@ -1,0 +1,27 @@
+var doesBrowserSupportWebComponents = function(){
+  /** determine the browser the code is being run on
+   * note: thanks to [stackoverflow](https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser/9851769) for the implementation
+   */
+  var isIE = !!document.documentMode;
+  var isEdge = !!window.StyleMedia;
+  var user_agent_supports_web_components = !isIE && !isEdge;
+  return user_agent_supports_web_components;
+};
+
+var loadWebComponentInto = function(tagname, replacedElement){
+  var user_agent_supports_web_components = doesBrowserSupportWebComponents();
+  if(user_agent_supports_web_components){
+    // show the component and hide its replacement
+    console.log("user_agent_supports_web_components! :)");
+    replacedElement.style.visibility = "hidden";
+  }else{
+    // hide the component itself
+    console.log("!user_agent_supports_web_components. :(");
+    console.log(tagname);
+    var lsElements = document.getElementsByTagName(tagname);
+    console.log(lsElements);
+    for(var i=0; i<lsElements.length; i++){
+      lsElements[i].style.visibility = "hidden";
+    }
+  }
+};

--- a/src/footer/footer.css
+++ b/src/footer/footer.css
@@ -1,5 +1,6 @@
 .footer-wrapper{
   background-color: #212121;
+  margin: 0 auto;
   color: white;
 }
 
@@ -33,18 +34,12 @@ footer {
   }
   .ftr-middle { border-bottom: solid transparent 1px !important; }
   .ftr-right  { border-bottom: solid transparent 1px !important; }
-  #sitemap {
-    width: 80%;
-    margin: 0 auto;
-  }
+  #sitemap { width: 80%; }
 }
 
 /* on super large screens, set the width to 80% to avoid getting too much spacing */
 @media only screen and (min-width: 1500px){
-  footer { 
-    margin: 0 auto;
-    width: 80%;
-  }
+  footer, #footer { width: 80%; }
 }
 
 /* map classes to grid areas */

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -10,22 +10,32 @@
 <!-- pull in bulib-wc components -->
 <script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/locoso/locoso.min.js" type="module"></script>
 <script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.2/src/footer/footer.min.js" type="module"></script>
+<script>
+  window.addEventListener('WebComponentsReady',function() {
+    loadWebComponentInto("bulib-footer", [ 
+      document.getElementById("footer-logo-container"),
+      document.querySelector("#footer-content > h2"),
+      document.getElementById("footer-info"),
+      document.getElementById("footer-links")
+    ]); 
+ });
+</script>
 
+<!-- before web components -->
+<div id="footer-info"><p>Boston University Libraries, 771 Commonwealth Avenue, Boston, MA 02215 | Reference Desk: 617-353-2700</p></div>
+
+<!-- after web components -->
 <style>
-  /* hide BU Logo and 'Libraries & Archives' heading */
-  #footer-logo-container, #footer-content > h2 { display: none; }
-
-  /* prevent overflow of footer width to 900px on small screensq */
+  /* prevent overflow of footer width to 900px at small widths */
   #footer > div.container { width: auto; }
   #footer-content { float: inherit; }
-  
-  /* firefox-specific adjustments for text color, link background, margins */
+
+  /* -- firefox -- */
   h3.style-scope.bulib-footer { color: white; }
   li.style-scope.bulib-footer { 
     background-image: none; 
     color: white;
     margin: unset;
-}
+  }
 </style>
-
 <bulib-footer library="mugar-memorial" host_site="wordpress"></bulib-footer>

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -67,7 +67,7 @@
       console.log("web components loaded");
       
       // show/hide empty tag (and slotted info) or what we're replacing given browser compatibility
-      loadWebComponentInto("bulib-header", document.getElementById("hide-me"));
+      loadWebComponentInto("bulib-header", [document.getElementById("hide-me")]);
     });
   </script>
 </body>

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -13,10 +13,15 @@
   <script src="../libsel/libsel.js" type="module"></script>
   <script src="../search/search.js" type="module"></script>
   <script src="../select/select.js" type="module"></script>
+  <script src="../_helpers/browser_compatibility.js"></script>
 </head>
 
+
 <body>
-  <bulib-header curr_url="http://askalibrarian.bu.edu" curr_search="help" str_options="help wp primo guides">
+  
+  <div id="hide-me"><h2>hide me please</h2></div>
+  
+  <bulib-header curr_url="http://askalibrarian.bu.edu" str_options="help">
     <div slot="secondary-nav-main">
       <div id="subsite-navigation" class="inline">
         <label for="askalib-btns">Subsite Navigation Label</label>
@@ -54,4 +59,15 @@
     sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 
     opt_code="wp_urls" tag_name="bulib-header" attr_name="curr_url"
   ></bulib-select>
+  <script>
+    console.log("userAgent: " + navigator.userAgent);
+    console.log("documentMode (only defined in IE): " + document.documentMode);
+    window.addEventListener('WebComponentsReady', function() {
+      // show body now that everything is ready
+      console.log("web components loaded");
+      
+      // show/hide empty tag (and slotted info) or what we're replacing given browser compatibility
+      loadWebComponentInto("bulib-header", document.getElementById("hide-me"));
+    });
+  </script>
 </body>

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -18,9 +18,6 @@
 
 
 <body>
-  
-  <div id="hide-me"><h2>hide me please</h2></div>
-  
   <bulib-header curr_url="http://askalibrarian.bu.edu" str_options="help">
     <div slot="secondary-nav-main">
       <div id="subsite-navigation" class="inline">


### PR DESCRIPTION
Jira Issue: [WEB-36](https://bulibrary.atlassian.net/browse/WEB-36)

### Background
- the current web components are written _in_ and imported _using_ ES6 modules
- IE 11 and Edge aren't entirely ES6 compliant and/or weren't effectively importing the components
- as we are looking to replace the _header_ of these soon, it's a big deal to hide the main navigational components without adding something else back in

### Description of Changes
- create new `browser_compatibility.js` helper
- add ES5 compatible `<script>` import to that consumes it
- tweak css hiding to make up for the changes