### PR TITLE
WEB-63: [bugfix] specify old lit-element version, increment tags

### DIFF
--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -31,8 +31,7 @@ const sitemap_values = {
       {"title":"Research Guides by Subject",  "href":"/guides"},
       {"title":"Course Guides",               "href":"https://www.bu.edu/library/research/guides/course-guides/"},
       {"title":"How-To Guides",               "href":"https://www.bu.edu/library/help/how-to/"},
-      {"title":"Make a Research Appointment", "href":"https://www.bu.edu/library/services/reference/appointments/"},
-      {"title":"Library Locations",           "href":"http://www.bu.edu/library/about/"}
+      {"title":"Make a Research Appointment", "href":"https://www.bu.edu/library/services/reference/appointments/"}
     ]
   }
 };
@@ -95,7 +94,7 @@ class BULFooter extends LitElement {
                 <ul class="no-bullet ptl">
                   <li><a class="white-link" href="https://www.bu.edu/library/" title="Libraries Home">Libraries Home</a></li>
                   <li><a class="white-link" href="http://bu.edu/library/search" title="Search available/licensed content">Libraries Search</a></li>
-                  <li><a class="white-link" href="http://bu.edu/library/about" title="Information regarding various BU Libraries">Libraries Locations</a></li>
+                  <li><a class="white-link" href="http://bu.edu/library/about" title="Information regarding various BU Libraries">Library Locations</a></li>
                   <li><a class="white-link" href="https://askalibrarian.bu.edu/" title="Help">Help</a></li>
                 </ul>
             </div>

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -75,8 +75,8 @@ class BULFooter extends LitElement {
 
     // render the main content of the component
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.2/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.2/src/footer/footer.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/assets/css/common.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.css">
       <style>
         /* firefox fix to stop the 'Follow Us' from becoming centered */
         ::slotted(h3) { text-align: left; }

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import { getLibraryCodeFromUrl } from '../_helpers/lib_info_helper.js';
 
 const debug = false;
@@ -75,8 +75,8 @@ class BULFooter extends LitElement {
 
     // render the main content of the component
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.2/assets/css/common.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.2/src/footer/footer.css">
       <style>
         /* firefox fix to stop the 'Follow Us' from becoming centered */
         ::slotted(h3) { text-align: left; }

--- a/src/footer/usages/_footer-includes.html
+++ b/src/footer/usages/_footer-includes.html
@@ -1,10 +1,11 @@
 <!-- Polyfills only needed for Firefox and Edge. -->
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@browser-v1.0/src/_helpers/browser_compatibility.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@locoso-v1.1/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.js" type="module"></script>

--- a/src/footer/usages/libanswers-footer.html
+++ b/src/footer/usages/libanswers-footer.html
@@ -2,14 +2,15 @@
 
 <!-- Polyfills only needed for Firefox and Edge. -->
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@browser-v1.0/src/_helpers/browser_compatibility.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@locoso-v1.1/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.js" type="module"></script>
 
 <div class="container">
   <bulib-footer library="help" host_site="askalibrarian"></bulib-footer>

--- a/src/footer/usages/libguides-footer.html
+++ b/src/footer/usages/libguides-footer.html
@@ -2,14 +2,15 @@
 
 <!-- Polyfills only needed for Firefox and Edge. -->
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@browser-v1.0/src/_helpers/browser_compatibility.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@locoso-v1.1/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.js" type="module"></script>
 
 <style type="text/css">
   /* style the 'Powered by Springshare' band 'Login to LibApps' link */

--- a/src/footer/usages/wordpress-footer.html
+++ b/src/footer/usages/wordpress-footer.html
@@ -5,12 +5,13 @@
 <script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@browser-v1.0/src/_helpers/browser_compatibility.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/locoso/locoso.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.5/src/footer/footer.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@locoso-v1.1/src/locoso/locoso.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.6.3/src/footer/footer.min.js" type="module"></script>
+
 <script>
   /* once the DOM tags have been loaded, use 'browser_compatibility' helper to show/hide relevant elements */
   window.addEventListener('DOMContentLoaded',function() {

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryCodeFromUrl} from '../_helpers/lib_info_helper.js';
 
 const debug = false;

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -30,8 +30,8 @@ class BULHeader extends LitElement {
   /** render the html (with 'bulib-search' wc) to the page  */
   render() {
     return html`
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.5/assets/css/common.min.css">
-      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.5/src/header/header.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/assets/css/common.min.css">
+      <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/src/header/header.min.css">
       <style>
         a { text-decoration: none; }
         .primary-navbar, .secondary-navbar > div { vertical-align: bottom; }

--- a/src/header/usages/libanswers-header.html
+++ b/src/header/usages/libanswers-header.html
@@ -4,13 +4,13 @@
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-bundle.min.js"></script>
 
 <!-- styling -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.5/assets/css/common.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.5/src/header/header.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/assets/css/common.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/src/header/header.css">
 
 <!-- pull in bulib-wc components -->
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.5/src/header/header.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@search-v0.8/src/search/search.min.js" type="module"></script>
-<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libsel-v0.7/src/libsel/libsel.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/src/header/header.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@search-v0.9/src/search/search.min.js" type="module"></script>
+<script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libsel-v0.9/src/libsel/libsel.min.js" type="module"></script>
 
 <style>
   /* clear out the existing askalibrarian header  */

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 
 const libhours = {
   "mugar-memorial":{"lid":1475,"url":"http://www.bu.edu/library/mugar-memorial/about/hours/"},

--- a/src/libsel/libsel.js
+++ b/src/libsel/libsel.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryInfoFromCode} from 'https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libsel-v0.7/src/_helpers/lib_info_helper.js?module';
 
 const debug = false;

--- a/src/libsel/libsel.js
+++ b/src/libsel/libsel.js
@@ -1,5 +1,5 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
-import {getLibraryInfoFromCode} from 'https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libsel-v0.7/src/_helpers/lib_info_helper.js?module';
+import {getLibraryInfoFromCode} from 'https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libsel-v0.8/src/_helpers/lib_info_helper.js?module';
 
 const debug = false;
 const change_url_on_select = true;

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
 
 const debug = false;

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 const ENTER_KEY_VALUE = 13;
 
 /* configurable defaults for logging, dropdown, submission action */

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@latest/lit-element.js?module';
+import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {search_options} from '../search/search.js';
 
 const debug = false;


### PR DESCRIPTION
Jira Ticket: [WEB-63](https://bulibrary.atlassian.net/browse/WEB-63)

### Background
- our web components are powered by a library called `lit-element`
- previously, we were using `latest` as the version and the package was named `@polymer/lit-element`
- recently, they updated the version from `0.6.4` to `2.0.0-rc.2` and changed the package to just `lit-element`
- this broke the ability to import the package like we were, so we have to specify a previous version until we switch over to using `package.json` and `webpack`

### Description of Changes
- add specification to the version of lit-element we were using
- publish new versions (tags) for each element and update usages