### PR TITLE
WEB-92: Add '<bulib-hours>' to header and simplify

### DIFF
--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -80,7 +80,7 @@ const libraries_data_backup = {
     "libcal_lid":1783
   },"sel":{
     "name":"Science & Engineering Library",
-    "short":"SEL Library",
+    "short":"SciEng Library",
     "website":"https://www.bu.edu/library/sel/",
     "address":["38 Cummington Mall","Boston, MA 02215"],
     "contacts":{"phone":"617-353-3733","fax":"617-353-3470"},

--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -5,6 +5,7 @@ const debug = false;
 const libraries_data_backup = {
   "mugar-memorial":{
     "name":"Mugar Memorial Library",
+    "short":"Mugar Library",
     "website":"https://www.bu.edu/library/mugar-memorial/",
     "address":["771 Commonwealth Avenue","Boston, MA 02215"],
     "contacts":{"phone":"617-353-2700","email":"ask@bu.edu"},
@@ -13,6 +14,7 @@ const libraries_data_backup = {
     "libcal_lid": 1475
   },"african-studies":{
     "name":"African Studies Library",
+    "short":"African Studies",
     "website":"https://www.bu.edu/library/african-studies/",
     "address":["771 Commonwealth Ave, 6th Floor","Boston, MA, 02215"],
     "contacts":{"phone":"617-353-3726"},
@@ -21,12 +23,14 @@ const libraries_data_backup = {
     "libcal_lid":1809
   },"medlib":{
     "name":"Alumni Medical Library",
+    "short":"Medical Library",
     "website":"https://medlib.bu.edu/",
     "address":["72 E Concord, L-12","Boston, MA 02118"],
     "contacts":{"phone":"617-358-2350","fax":"617-358-2347","email":"refquest@bu.edu"},
     "hours_url": "http://www.bumc.bu.edu/medlib/about-us/hours/"
   },"astronomy":{
     "name":"Astronomy Library",
+    "short":"Astronomy Library",
     "website":"https://www.bu.edu/library/astronomy/",
     "address":["725 Commonwealth Avenue","Boston, MA 02445"],
     "contacts":{"phone":"617-353-2625"},
@@ -34,12 +38,14 @@ const libraries_data_backup = {
     "libcal_lid":1784
   },"lawlibrary":{
     "name":"Fineman & Pappas Law Libraries",
+    "short":"Law Library",
     "website":"https://www.bu.edu/lawlibrary/",
     "address":["765 Commonwealth Ave, 2nd Floor","Boston, MA 02215"],
     "contacts":{"phone":"617-353-8411","text":"1-617-997-4475"},
     "hours_url":"http://www.bu.edu/lawlibrary/using-the-library/access-policy/"
   },"hgar":{
     "name":"Howard Gotlieb Archival Research Center",
+    "short":"BU Archive",
     "website":"http://archives.bu.edu/",
     "address":["771 Commonwealth Ave, 5th Floor","Boston, MA 02215"],
     "contacts":{"phone":"617-353-3696","fax":"617-353-2838","email":"archives@bu.edu"},
@@ -47,6 +53,7 @@ const libraries_data_backup = {
     "hours_url":"http://archives.bu.edu/web/guest/about"
   },"music":{
     "name":"Music Library",
+    "short":"Music Library",
     "website":"https://www.bu.edu/library/music/",
     "address":["771 Commonwealth Ave, Floor 2","Boston, MA 02215"],
     "contacts":{"phone":"617-353-3705","email":"musiclib@bu.edu"},
@@ -55,6 +62,7 @@ const libraries_data_backup = {
     "libcal_lid":1810
   },"pardee":{
     "name":"Pardee Management Library",
+    "short":"Pardee Library",
     "website":"https://www.bu.edu/library/management/",
     "address":["595 Commonwealth Avenue","Boston, MA 02215"],
     "contacts":{"phone":"617-353-4301","fax":"617-353-4307","email":"pardstf@bu.edu"},
@@ -63,6 +71,7 @@ const libraries_data_backup = {
     "libcal_lid":1476
   },"pickering":{
     "name":"Pickering Educational Resources Library",
+    "short":"Pickering Library",
     "website":"https://www.bu.edu/library/pickering-educational/",
     "address":["2 Silber Way","Boston, MA 02215"],
     "contacts":{"phone":"617-353-3734"},
@@ -71,6 +80,7 @@ const libraries_data_backup = {
     "libcal_lid":1783
   },"sel":{
     "name":"Science & Engineering Library",
+    "short":"SEL Library",
     "website":"https://www.bu.edu/library/sel/",
     "address":["38 Cummington Mall","Boston, MA 02215"],
     "contacts":{"phone":"617-353-3733","fax":"617-353-3470"},
@@ -79,6 +89,7 @@ const libraries_data_backup = {
     "libcal_lid":1477
   },"stone":{
     "name":"Stone Science Library",
+    "short":"Stone Library",
     "website":"https://www.bu.edu/library/stone-science/",
     "address":["675 Commonwealth Ave, Floor 2","Boston, MA 02445"],
     "contacts":{"phone":"617-353-5679"},
@@ -86,6 +97,7 @@ const libraries_data_backup = {
     "libcal_lid":1785
   },"theology":{
     "name":"School of Theology Library",
+    "short":"Theology Library",
     "website":"https://www.bu.edu/sthlibrary/",
     "address":["745 Commonwealth Ave, Floor 2","Boston, MA 02215"],
     "contacts":{"phone":"617-353-3034","fax":"617-358-0698","email":"sthlib@bu.edu"},
@@ -93,6 +105,7 @@ const libraries_data_backup = {
     "hours_url":"https://www.bu.edu/sthlibrary/for-visitors/directions/"
   },"help":{
     "name":"BU Libraries",
+    "short":"BU Libraries",
     "website":"http://bu.edu/library",
     "address":["771 Commonwealth Avenue","Boston, MA 02215"],
     "contacts":{"phone":"617-353-2700","email":"ask@bu.edu","text":"617-431-2427"},

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -3,10 +3,9 @@
 .main-menu-items > ul { padding-left: 10px !important; }
 .main-menu-items > ul > li { padding: 0px 10px; }
 .main-menu-items > ul > li > a { color: white; }
-.main-menu-items > ul > li.active > a { color: #FFC20E; }
+.main-menu-items > ul > li.active > a { text-color: #FFC20E; }
 
 .primary-navbar { background-color: #212121 !important; }
-.secondary-navbar { background-color: #f5f5f5 !important; }
 
 .primary-nav-main > ul { padding-left: 0px; }
 .right { float:right; }
@@ -30,6 +29,6 @@
 /* medium-sized screen */
 @media only screen and (min-width: 800px){
   .primary-navbar, .secondary-navbar {
-    grid-template-areas:"hdr-lt hdr-md hdr-md hdr-md hdr-rt hdr-rt";
+    grid-template-areas:"hdr-lt hdr-lt hdr-md hdr-md hdr-rt hdr-rt";
   }
 }

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -13,42 +13,11 @@
   <script src="../libsel/libsel.js" type="module"></script>
   <script src="../search/search.js" type="module"></script>
   <script src="../select/select.js" type="module"></script>
+  <script src="../libhours/libhours.js" type="module"></script>
 </head>
 
 <body>
-  <bulib-header curr_url="http://askalibrarian.bu.edu" str_options="help">
-    <div slot="secondary-nav-main">
-      <div id="subsite-navigation" class="inline">
-        <label for="askalib-btns">Subsite Navigation Label</label>
-        <ul id="askalib-btns" class="nav navbar-nav s-la-navbrowse">
-          <!-- Navigate through parts of the site at a high level -->
-          <li class="dropdown">
-            <a data-toggle="dropdown" class="dropdown-toggle" href="#" aria-haspopup="true" aria-expanded="false">Sections of the Site</a>
-            <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="s-la-browse-group-drop" aria-hidden="true">
-              <li><a href="#" role="menuitem">Section of Site 1</a></li>
-              <li><a href="#" role="menuitem">Section of Site 2</a></li>
-              <li><a href="#" role="menuitem">Section of Site 3</a></li>
-            </ul>
-          </li>
-          <!-- select additional pages at a more granular level -->
-          <li class="dropdown">
-            <a data-toggle="dropdown" class="dropdown-toggle" href="#" aria-haspopup="true" aria-expanded="false">Granular pages within the site</a>
-            <ul class="dropdown-menu dropdown-scroll dropdown-menu-right" role="menu" aria-hidden="true">
-              <li><a href="#" role="menuitem">Page 1</a></li>
-              <li><a href="#" role="menuitem">Page 2</a></li>
-              <li><a href="#" role="menuitem">Page 3</a></li>
-              <li><a href="#" role="menuitem">Page 4</a></li>
-              <li><a href="#" role="menuitem">Page 5</a></li>
-              <li><a href="#" role="menuitem">Page 6</a></li>
-              <li><a href="#" role="menuitem">Page 7</a></li>
-              <li><a href="#" role="menuitem">Page 8</a></li>
-              <li><a href="#" role="menuitem">Page 9</a></li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </bulib-header>
+  <bulib-header curr_url="http://askalibrarian.bu.edu"></bulib-header>
   <br /><hr /><br />
   <bulib-select 
     sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -7,23 +7,15 @@ const local = true;
 /** Reactive/responsive header with custom subsite display, bulib-search integration */
 class BULHeader extends LitElement {
 
-  constructor(){ super(); }
-
   /** store information on the current page */
   static get properties() {
     return {
-      /** current url used in testing to determine site */
-      curr_url: {type: String, notify:true},
-      /** current primary site [e.g. 'research', 'services', 'about', 'help'] */
+      // current url used in testing to determine site
+      curr_url: {type: String},
+      // current primary site [e.g. 'research', 'services', 'about', 'help'] 
       curr_primary: {type: String},
-      /** current secondary site (within each primary) [e.g. 'guides', 'help', '{library-names}'] */
-      curr_secondary: {type: String},
-      /** currently active search style [e.g. 'primo', 'guides', 'wp', 'faq', ... ] */
-      curr_search: {type: String},
-      /** options included in search dropdown (passed to <-search>) */
-      str_options: {type: String},
-      /** whether or not the current user is logged in */
-      logged_in: {type: Boolean}
+      // current library (sent to hours) 
+      library: {type: String}
     };
   }
 
@@ -34,7 +26,6 @@ class BULHeader extends LitElement {
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/src/header/header.min.css">
       <style>
         a { text-decoration: none; }
-        .primary-navbar, .secondary-navbar > div { vertical-align: bottom; }
         .right { float:right; }
         .mvm { margin: 15px 0px; }
         .txtr { text-align: right; }
@@ -47,39 +38,21 @@ class BULHeader extends LitElement {
             </a>
           </div>
           <div class="main-menu-items primary-nav-main">
-            <ul id="site-links" class="nav navbar-nav inline-list">
+            <ul id="site-links" class="inline-list">
               <li id="subsite-research"><a href="https://www.bu.edu/library/research/">Research</a></li>
               <li id="subsite-services"><a href="https://www.bu.edu/library/services/">Services</a></li>
               <li id="subsite-about"><a href="https://www.bu.edu/library/about/">About</a></li>
-              <li id="subsite-help" class="active"><a href="http://askalibrarian.bu.edu/">Help</a></li>
+              <li id="subsite-help"><a href="http://askalibrarian.bu.edu/">Help</a></li>
             </ul>
           </div>
-          <div class="primary-nav-right phm right mvm">
-            <slot name="primary-nav-right">
-              <bulib-libsel class="right"></bulib-libsel>
-            </slot>
-          </div>
-        </div>
-        <div class="secondary-navbar">
-          <div class="secondary-nav-left pam">
-            <slot name="secondary-nav-left">
-              <strong>${this.curr_secondary}</strong>
-            </slot>
-          </div>
-          <div class="secondary-nav-main pam">
-            <slot name="secondary-nav-main"></slot>
-          </div>
-          <div class="secondary-nav-right pam">
-            <bulib-search str_selected="${this.curr_search}" str_options="${this.str_options}" class="txtr"></bulib-search>
+          <div class="primary-nav-right phm right">
+            <div class="mvm right"><bulib-hours library="${this.library}" link_class="white-link"></bulib-hours></div>
           </div>
         </div>
       </nav>`;
   }
-
-  /** for production purposes, react to url updating when the component is first loaded */
-  connectedCallback(){
-    if(!local) { this._urlUpdated(); }
-  }
+  
+  connectedCallback(){ this._urlUpdated(); }
 
   /** for development purposes, react to manual changes to `this.curr_url` via _urlUpdated */
   attributeChangedCallback(name, oldValue, newValue){
@@ -95,7 +68,10 @@ class BULHeader extends LitElement {
   /** set primary nav 'active' styling */
   _primaryUpdated(){
     let i, li;
-    let lsListItems = this.shadowRoot.querySelector("#site-links").getElementsByTagName("li");
+    let siteLinksElem = this.shadowRoot.querySelector("#site-links");
+    if(!siteLinksElem){ return; }
+    
+    let lsListItems = siteLinksElem.getElementsByTagName("li");
     for(i = 0; i<lsListItems.length; i++) {
       li = lsListItems[i];
       if((li.id).includes(this.curr_primary)){ li.classList.add("active"); }
@@ -110,42 +86,22 @@ class BULHeader extends LitElement {
     let old_primary = this.curr_primary;
     if(currentUrl.includes("askalibrarian")){
       this.curr_primary = "help";
-      this.curr_secondary = "Ask a Librarian";
-      this.curr_search  = "help";
     }else if(currentUrl.includes("buprimo") || currentUrl.includes("exlibrisgroup")){
       this.curr_primary = "search";
-      this.curr_secondary = "Search";
-      this.curr_search  = "primo";
     }else if(currentUrl.includes(".bu.edu/library")){
 
-      // Guides
-      if(currentUrl.includes("/research")){
-       this.curr_primary = "research";
-       this.curr_secondary = "Guides";
-       this.curr_search  = "guides";
-      }
-
-      // Services
-      else if(currentUrl.includes("/services")){
-        this.curr_primary = "services";
-        this.curr_secondary = "Services";
-        this.curr_search  = "wp";
-      }
-
-      // About
-      else{
-        this.curr_primary = "about";
-        this.curr_search = "wp";
-        this.curr_secondary = getLibraryCodeFromUrl(currentUrl) || "mugar-memorial";
-      }
+      if(currentUrl.includes("/research")){ this.curr_primary = "research"; }
+      else if(currentUrl.includes("/services")){ this.curr_primary = "services"; }
+      else{ this.curr_primary = "about"; }
+      this.library = getLibraryCodeFromUrl(currentUrl);
     }
 
     // TODO remove and deal with changes in a nicer, more standardized way
-    if(old_primary && old_primary !== this.curr_primary) { this._primaryUpdated(); }
+    if(!old_primary || old_primary !== this.curr_primary) { this._primaryUpdated(); }
 
     // add debug info
     if(debug){
-      console.log(`bulib-header) curr_primary: '${this.curr_primary}', curr_secondary: '${this.curr_secondary}', curr_search: '${this.curr_search}'`);
+      console.log(`bulib-header) curr_primary: '${this.curr_primary}'`);
     }
   }
 

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -1,21 +1,19 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryCodeFromUrl} from '../_helpers/lib_info_helper.js';
 
-const debug = false;
-const local = true;
-
 /** Reactive/responsive header with custom subsite display, bulib-search integration */
 class BULHeader extends LitElement {
 
   /** store information on the current page */
   static get properties() {
     return {
+      // current library (sent to hours) 
+      library: {type: String},
+      
       // current url used in testing to determine site
       curr_url: {type: String},
-      // current primary site [e.g. 'research', 'services', 'about', 'help'] 
-      curr_primary: {type: String},
-      // current library (sent to hours) 
-      library: {type: String}
+      // debugging tools
+      debug: {type: Boolean}
     };
   }
 
@@ -52,21 +50,19 @@ class BULHeader extends LitElement {
       </nav>`;
   }
   
-  connectedCallback(){ this._urlUpdated(); }
+  connectedCallback(){  this._urlUpdated(); }
 
   /** for development purposes, react to manual changes to `this.curr_url` via _urlUpdated */
   attributeChangedCallback(name, oldValue, newValue){
     super.attributeChangedCallback(name, oldValue, newValue);
-    if(debug){ console.log(`bulib-header) attributeChangedCallback() called, changing '${name}' from '${oldValue}' to '${newValue}'...`); }
     switch(name){
       case "curr_url":      this._urlUpdated(); break;
-      case "curr_primary":  this._primaryUpdated(); break;
       default: break;
     }
   }
 
   /** set primary nav 'active' styling */
-  _primaryUpdated(){
+  _primaryUpdated(newPrimary){
     let i, li;
     let siteLinksElem = this.shadowRoot.querySelector("#site-links");
     if(!siteLinksElem){ return; }
@@ -81,7 +77,7 @@ class BULHeader extends LitElement {
 
   /** set the primary, secondary, and search information according to the currentUrl  */
   _urlUpdated(){
-    let currentUrl = (local)? this.curr_url : window.location.href;
+    let currentUrl = (this.curr_url)? this.curr_url : window.location.href;
 
     let old_primary = this.curr_primary;
     if(currentUrl.includes("askalibrarian")){
@@ -94,15 +90,20 @@ class BULHeader extends LitElement {
       else if(currentUrl.includes("/services")){ this.curr_primary = "services"; }
       else{ this.curr_primary = "about"; }
       this.library = getLibraryCodeFromUrl(currentUrl);
+      this._logToConsole(`library set to '${this.library}'.`);
+    }else{
+      this.curr_primary = "about";
     }
 
     // TODO remove and deal with changes in a nicer, more standardized way
-    if(!old_primary || old_primary !== this.curr_primary) { this._primaryUpdated(); }
-
-    // add debug info
-    if(debug){
-      console.log(`bulib-header) curr_primary: '${this.curr_primary}'`);
+    if(!old_primary || old_primary != this.curr_primary) { 
+      this._primaryUpdated(); 
+      this._logToConsole(`curr_primary: changed from '${old_primary || ""}' to '${this.curr_primary}'.`);
     }
+  }
+  
+  _logToConsole(message){
+    if(this.debug){ console.log("bulib-header) " + message); }
   }
 
 }

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -46,7 +46,7 @@ class BULHeader extends LitElement {
             </ul>
           </div>
           <div class="primary-nav-right phm right">
-            <div class="mvm right"><bulib-hours library="${this.library}" link_class="white-link"></bulib-hours></div>
+            <div class="mvm right"><bulib-hours show_name library="${this.library}" link_class="white-link"></bulib-hours></div>
           </div>
         </div>
       </nav>`;

--- a/src/libhours/libhours.html
+++ b/src/libhours/libhours.html
@@ -15,7 +15,7 @@
 
 </head>
 <body>
-  <h1>test</h1>
+  <h1><code>&lt;bulib-hours&gt;</code></h1>
   <bulib-hours></bulib-hours>
   <br /><hr /><br />
   <bulib-select

--- a/src/libhours/libhours.html
+++ b/src/libhours/libhours.html
@@ -15,8 +15,22 @@
 
 </head>
 <body>
+  <style> 
+    .demo{ text-align: center; margin: 30px; }
+    code { background-color: gainsboro; }  
+  </style>
   <h1><code>&lt;bulib-hours&gt;</code></h1>
-  <bulib-hours></bulib-hours>
+  <p><em>display the current hours of a given library (informed by url)</em></p>
+  <br /><hr /><br />
+  <div class="demo">
+    <h3>&lt;bulib-hours&gt;</h3>
+    <bulib-hours></bulib-hours>
+  </div>
+  <br /><hr /><br />
+  <div class="demo">
+    <h3>&lt;bulib-hours <code>verbose</code>&gt;</h3>
+    <bulib-hours verbose></bulib-hours>
+  </div>
   <br /><hr /><br />
   <bulib-select
     sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -6,11 +6,6 @@ import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
 const all_lib_hours_url = "http://www.bu.edu/library/about/hours/";
 const cors_anywhere_prefix = 'https://cors-anywhere.herokuapp.com/';
 const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
-const _fetchHoursData = function(lid=1475){
-  let url = `${cors_anywhere_prefix}${libcal_hours_api_url}?format=json&systemTime=0&iid=1740&lid=${lid}`;
-  return fetch( url, { method: 'GET', mode:'cors'})
-    .then(r => r.json()).then(data => (data.locations[0]).rendered);
-};
 
 
 /** display the hours of operation for a given library */
@@ -22,9 +17,18 @@ class BULibHours extends LitElement {
     return { 
       library: {type: String}, 
       verbose: {type: Boolean},
-      link_class: {type: String}
+      link_class: {type: String},
+      
+      debug: {type: Boolean}
     };
   }
+  
+  _fetchHoursData = function(lid=1475){
+    let url = `${cors_anywhere_prefix}${libcal_hours_api_url}?format=json&systemTime=0&iid=1740&lid=${lid}`;
+    this._logToConsole("calling 'libcal' with lid: '" + lid + "'.");
+    return fetch( url, { method: 'GET', mode:'cors'})
+      .then(r => r.json()).then(data => (data.locations[0]).rendered);
+  };
 
   render() {
     // get general library information
@@ -38,7 +42,8 @@ class BULibHours extends LitElement {
     if(library_name.includes("BU Librar")){ library_name = "Mugar Library"; }
 
     // prepare templates
-    let hours_loading = html`<em id="hours-display" class="gold">${until(_fetchHoursData(lid), html`<small> loading hours...</small>`)}</em>`;
+    this._logToConsole(`rendering hours for ${library_name} (code:'${libCode}').`);
+    let hours_loading = html`<em id="hours-display" class="gold">${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}</em>`;
     let hours_link = html`<a title="see full hours for ${library_name}" class="${this.link_class}" href="${hours_url}">hours</a>`;
     let see_all_link = html`<small><a href="${all_lib_hours_url}" class=${this.link_class}>(all location hours)</a></small>`;
 
@@ -58,6 +63,10 @@ class BULibHours extends LitElement {
         <div id="hours-bottom">${this.verbose? html`${hours_loading} ${see_all_link}` : html`` }</div>
       </div>
       `;
+  }
+  
+  _logToConsole = function(message){
+    if(this.debug){ console.log("bulib-hours) " + message); }
   }
 
 }

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -14,12 +14,13 @@ const _fetchHoursDataFromLibCalForLibrary = function(lid=1475){
 
 /** display the hours of operation for a given library */
 class BULibHours extends LitElement {
-    
+
   createRenderRoot(){ return this; } // don't need 'slot' functionality, so lets use Light DOM
 
   static get properties() {
     return { 
-      library: {type: String}
+      library: {type: String},
+      show_name: {type: Boolean}
     };
   }
 
@@ -31,12 +32,14 @@ class BULibHours extends LitElement {
     // extract relevant pieces from lib_info
     let library_name = lib_info.name;
     let hours_url = lib_info.hours_url;
-    let lid = lib_info.libcal_lid || 1475;
+    let lid = lib_info.libcal_lid;
 
     return html`
       <div class="libhours">
-        <strong>${library_name} <a title="${library_name} hours" href="${hours_url}">hours</a></strong>
-        <em id="hours-display">: ${until(_fetchHoursDataFromLibCalForLibrary(lid), html`loading ...`)}</em> 
+        <strong>${this.show_name? html`${library_name}`: html``}
+          <a title="${library_name} hours" href="${hours_url}">hours</a>
+        </strong>
+        <em id="hours-display">${until(_fetchHoursDataFromLibCalForLibrary(lid), html` loading ...`)}</em> 
       </div>`;
   }
 

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -3,6 +3,7 @@ import {until} from 'https://unpkg.com/lit-html@1.0.0/directives/until.js?module
 
 import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
 
+const all_lib_hours_url = "http://www.bu.edu/library/about/hours/";
 const cors_anywhere_prefix = 'https://cors-anywhere.herokuapp.com/';
 const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
 const _fetchHoursDataFromLibCalForLibrary = function(lid=1475){
@@ -15,34 +16,48 @@ const _fetchHoursDataFromLibCalForLibrary = function(lid=1475){
 /** display the hours of operation for a given library */
 class BULibHours extends LitElement {
 
-  createRenderRoot(){ return this; } // don't need 'slot' functionality, so lets use Light DOM
+  createRenderRoot(){ return this;} // don't need 'slot' functionality, so lets use Light DOM
 
   static get properties() {
     return { 
       library: {type: String}, 
-      show_name: {type: Boolean},
+      verbose: {type: Boolean},
       link_class: {type: String}
     };
   }
 
   render() {
+    this.verbose = true; 
     // get general library information
     let libCode = this.library || "mugar-memorial";
     let lib_info = getLibraryInfoFromCode(libCode);
     
     // extract relevant pieces from lib_info
-    let library_name = lib_info.name;
+    let library_name = lib_info.short || lib_info.name;
     let hours_url = lib_info.hours_url;
     let lid = lib_info.libcal_lid;
 
+    // default to labeling default as mugar-specific
+    if(library_name.includes("BU Librar")){ library_name = "Mugar Library"; }
+
     return html`
-      <style> :host { color: white; } </style>
+      <style> 
+        :host { color: white; } 
+        .libhours { text-align: center; }
+        .gold { color: gold; }
+      </style>
       <div class="libhours">
-        <strong>${this.show_name? html`${library_name}`: html``}
-          <a title="${library_name} hours" class="${this.link_class}" href="${hours_url}">hours</a>
-        </strong>
-        <em id="hours-display">${until(_fetchHoursDataFromLibCalForLibrary(lid), html` loading ...`)}</em> 
-      </div>`;
+        <div id="single-library">
+          <strong>${this.verbose? html`${library_name}`: html``}
+            <a title="${library_name} hours" class="${this.link_class}" href="${hours_url}">hours</a>
+          </strong>
+        </div>
+        <div>
+          <em id="hours-display" class="gold">${until(_fetchHoursDataFromLibCalForLibrary(lid), html`<small> loading hours...</small>`)}</em> 
+          ${this.verbose? html`<small><a class="${this.link_class}" href="${all_lib_hours_url}">(all location hours)</a><small>`: html``}
+        </div>
+      </div>
+      `;
   }
 
 }

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -19,8 +19,9 @@ class BULibHours extends LitElement {
 
   static get properties() {
     return { 
-      library: {type: String},
-      show_name: {type: Boolean}
+      library: {type: String}, 
+      show_name: {type: Boolean},
+      link_class: {type: String}
     };
   }
 
@@ -35,9 +36,10 @@ class BULibHours extends LitElement {
     let lid = lib_info.libcal_lid;
 
     return html`
+      <style> :host { color: white; } </style>
       <div class="libhours">
         <strong>${this.show_name? html`${library_name}`: html``}
-          <a title="${library_name} hours" href="${hours_url}">hours</a>
+          <a title="${library_name} hours" class="${this.link_class}" href="${hours_url}">hours</a>
         </strong>
         <em id="hours-display">${until(_fetchHoursDataFromLibCalForLibrary(lid), html` loading ...`)}</em> 
       </div>`;

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -22,8 +22,14 @@ const wp_urls = [
   {"name":"Primo Search",   "value":"buprimo.hosted.exlibrisgroup.com/primo-explore/search"},
   {"name":"Guides",         "value":"www.bu.edu/library/research/guides/course-guides/"},
   {"name":"Services",       "value":"http://www.bu.edu/library/services/"},
-  {"name":"Mugar Library",  "value":"www.bu.edu/library/mugar-memorial"},
   {"name":"African Studies","value":"https://www.bu.edu/library/african-studies/", },
+  {"name":"Astronomy Library","value":"http://www.bu.edu/library/astronomy/", },
+  {"name":"Music Library",  "value":"http://www.bu.edu/library/music/"},
+  {"name":"Mugar Library",  "value":"www.bu.edu/library/mugar-memorial"},
+  {"name":"Pardee Library", "value":"http://www.bu.edu/library/management/", },
+  {"name":"Pickering Library","value":"http://www.bu.edu/library/pickering-educational/"},
+  {"name":"Science & Engineering","value":"http://www.bu.edu/library/sel/", },
+  {"name":"Stone Library",  "value":"http://www.bu.edu/library/stone-science/"},
   {"name":"Help",           "value":"askalibrarian.bu.edu/"}
 ];
 const sites = [


### PR DESCRIPTION
### Description of Changes
- add information to `lib_info_helper.js` (`short`, `hours_url`, `libcal_lid`)
- remove secondary bar from `<bulib-header>` element (simpler, more universal)
- adjust `libhours.[js, html]` to be truly functional

### Screenshots

#### Documentation
![documentation showing both](https://user-images.githubusercontent.com/5565284/55034121-1e8d5b00-4feb-11e9-866f-f35d06065302.png)

#### In Context (`bulib-header`)
**verbose**
![on header with verbose](https://user-images.githubusercontent.com/5565284/55033282-2e0ba480-4fe9-11e9-8131-306bc546b93f.png)
**plain**
![on header without verbose](https://user-images.githubusercontent.com/5565284/55033318-411e7480-4fe9-11e9-8c04-1b685da75b7f.png)

