### PR TITLE
WEB-94: enable live debugging without redeploy (`debug`, `prevent_action`)

### DIFF
--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -1,4 +1,4 @@
-import {_getDataFromFile} from './load_json.js';
+// import {_getDataFromFile} from './load_json.js';
 
 const libraries_data_backup = {
   "mugar-memorial":{
@@ -124,7 +124,7 @@ export function getSiteCodeFromUrl(url, debug=false, defSiteCode="help"){
   let site_code = "about";
   if(url.includes("askalibrarian")){ site_code = "help"; }
   // else if(url.includes("openbu")){ site_code = "collections"; }
-  // else if(url.includes("guides")){ site_code = "guides" }
+  else if(url.includes("guides")){ site_code = "guides" }
   else if(url.includes("buprimo") || url.includes("exlibrisgroup")){ site_code = "research"/*"search"*/; }
   
   else if(url.includes(".bu.edu/library")){

--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -1,7 +1,5 @@
 import {_getDataFromFile} from './load_json.js';
 
-const debug = false;
-
 const libraries_data_backup = {
   "mugar-memorial":{
     "name":"Mugar Memorial Library",
@@ -115,14 +113,31 @@ const libraries_data_backup = {
   }
 };
 
-export function getLibraryInfoFromCode(lib_code, defLibCode="help"){
+export function getLibraryInfoFromCode(lib_code, debug=false, defLibCode="help"){
   let libraries_data = /* TODO: _getDataFromFile("lib_info.json") || */ libraries_data_backup;
   let library_data = libraries_data[lib_code] || libraries_data[defLibCode];
-  if(debug){ console.log(`_lib_info_helper) getting library_data for code: '${lib_code}' with default '${defLibCode}'.`);}
+  logToConsole(`getting library_data for code: '${lib_code}' with default '${defLibCode}'.`, debug);
   return library_data;
 }
 
-export function getLibraryCodeFromUrl(lib_url, defLibCode="help"){
+export function getSiteCodeFromUrl(url, debug=false, defSiteCode="help"){
+  let site_code = "about";
+  if(url.includes("askalibrarian")){ site_code = "help"; }
+  // else if(url.includes("openbu")){ site_code = "collections"; }
+  // else if(url.includes("guides")){ site_code = "guides" }
+  else if(url.includes("buprimo") || url.includes("exlibrisgroup")){ site_code = "research"/*"search"*/; }
+  
+  else if(url.includes(".bu.edu/library")){
+    if(url.includes("/research")){ site_code = "research"; }
+    else if(url.includes("/services")){ site_code = "services"; }
+    else{ site_code = "about"; }
+  }else{ site_code = "about"; }
+  
+  logToConsole(`site_code '${site_code}' extracted from url '${url}'.`, debug);
+  return site_code;
+}
+
+export function getLibraryCodeFromUrl(lib_url, debug=false, defLibCode="help"){
   let lib_code = defLibCode;
   if(lib_url.includes("bu.edu/library/")){
     // try to get {library_code} from url 'http://www.bu.edu/library/{stone-science}/research/guides/'
@@ -144,6 +159,10 @@ export function getLibraryCodeFromUrl(lib_url, defLibCode="help"){
     else { lib_code = "help"; }
   }
   if(!Object.keys(libraries_data_backup).includes(lib_code)){ lib_code = "help"; }
-  if(debug){ console.log(`_lib_info_helper) returning lib_code '${lib_code}' from lib_url '${lib_url}'.`); }
+  logToConsole(`lib_code '${lib_code}' from lib_url '${lib_url}'`, debug);
   return lib_code;
 }
+
+const logToConsole = function(message, debug=false){
+  if(debug){ console.log("lib_info_helper) " + message); }
+};

--- a/src/footer/footer.html
+++ b/src/footer/footer.html
@@ -16,7 +16,7 @@
     <script src="../select/select.js" type="module"></script>
   </head>
   <body>
-    <bulib-footer curr_url="http://www.bu.edu/library/music/research/guides/"></bulib-footer>
+    <bulib-footer debug></bulib-footer>
     <br /><hr /><br />
     <bulib-select 
       sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 

--- a/src/footer/footer.html
+++ b/src/footer/footer.html
@@ -16,16 +16,11 @@
     <script src="../select/select.js" type="module"></script>
   </head>
   <body>
-    <bulib-footer host_site="askalibrarian"></bulib-footer>
+    <bulib-footer curr_url="http://www.bu.edu/library/music/research/guides/"></bulib-footer>
     <br /><hr /><br />
-    <bulib-select
-      sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"
-      tag_name="bulib-footer" attr_name="library">
-    </bulib-select>
-    <br /><br />
-    <bulib-select
-      sel_title="Select Site" curr_sel="help" opt_code="sites"
-      tag_name="bulib-footer" attr_name="host_site">
-    </bulib-select>
+    <bulib-select 
+      sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 
+      opt_code="sample_urls" tag_name="bulib-footer" attr_name="curr_url"
+  ></bulib-select>
   </body>
 </html>

--- a/src/footer/footer.html
+++ b/src/footer/footer.html
@@ -16,8 +16,17 @@
     <script src="../select/select.js" type="module"></script>
   </head>
   <body>
-    <bulib-footer debug></bulib-footer>
+    <h1><code>bulib-footer</code></h1>
+    <p><em>BU-branded footer for use across our many sites</em></p>
+    <p><small>*includes <code>&lt;bulib-locoso&gt;</code></small></p>
+    <p><small>**reacts to the current (or simulated) url (<code>curr_url</code></small>)</p>
+    
     <br /><hr /><br />
+    
+    <bulib-footer debug></bulib-footer>
+    
+    <br /><hr /><br />
+    
     <bulib-select 
       sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 
       opt_code="sample_urls" tag_name="bulib-footer" attr_name="curr_url"

--- a/src/footer/footer.html
+++ b/src/footer/footer.html
@@ -21,6 +21,6 @@
     <bulib-select 
       sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 
       opt_code="sample_urls" tag_name="bulib-footer" attr_name="curr_url"
-  ></bulib-select>
+    ></bulib-select>
   </body>
 </html>

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -59,7 +59,7 @@ class BULFooter extends LitElement {
     
     // determine site
     let old_site = this.host_site;
-    let main_site = getSiteCodeFromUrl(current_url);
+    let main_site = getSiteCodeFromUrl(current_url, this.debug);
     if(["about","research","services"].includes(main_site)){ this.host_site = "wordpress"; }
     else if(main_site == "help"){ this.host_site = "askalibrarian"; }
     else if(main_site == "guides"){ this.host_site = "guides"; }
@@ -70,7 +70,7 @@ class BULFooter extends LitElement {
     
     // determine library
     let old_library = this.library;
-    let lib_code = getLibraryCodeFromUrl(current_url);
+    let lib_code = getLibraryCodeFromUrl(current_url, this.debug);
     this.library = lib_code;
     if(old_library != this.library){
       this._logToConsole(`library changed from '${old_library}' to '${this.library}'.`);

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -1,8 +1,5 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
-import { getLibraryCodeFromUrl } from '../_helpers/lib_info_helper.js';
-
-const debug = false;
-const local = false;
+import {getSiteCodeFromUrl, getLibraryCodeFromUrl} from '../_helpers/lib_info_helper.js';
 
 /** stored values for the sitemap */
 const sitemap_values = {
@@ -49,15 +46,27 @@ class BULFooter extends LitElement {
       /** provide window into setting displayed 'locoso' contact data */
       library: {type: String, notify:true},
       /** key for the subsite (used to populate the sitemap) */
-      host_site: {type: String}
+      host_site: {type: String},
+      
+      debug: {type: Boolean},
+      curr_url: {type: String}
     };
   }
 
   /** upon the element's first connection to the DOM, get the url and use it to determine $this.library */
-  connectedCallback(){
-    let current_url = local? "http://www.bu.edu/library/music/research/guides/" : window.location.href;
+  updated(){
+    let current_url = this.curr_url? this.curr_url : window.location.href
+    
+    // determine site
+    let main_site = getSiteCodeFromUrl(current_url);
+    if(["about","research","services"].includes(main_site)){ this.host_site = "wordpress"; }
+    else if(main_site == "help"){ this.host_site = "askalibrarian"; }
+    else if(main_site == "guides"){ this.host_site = "guides"; }
+    else{ this.host_site = "askalibrarian"; }
+    
+    // determine library
     let lib_code = getLibraryCodeFromUrl(current_url);
-    if(debug){ console.log("bulib-footer) selected library code: " + lib_code); }
+    if(this.debug){ console.log("bulib-footer) selected library code: " + lib_code); }
     this.library = lib_code;
   }
 

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -55,19 +55,26 @@ class BULFooter extends LitElement {
 
   /** upon the element's first connection to the DOM, get the url and use it to determine $this.library */
   updated(){
-    let current_url = this.curr_url? this.curr_url : window.location.href
+    let current_url = this.curr_url? this.curr_url : window.location.href;
     
     // determine site
+    let old_site = this.host_site;
     let main_site = getSiteCodeFromUrl(current_url);
     if(["about","research","services"].includes(main_site)){ this.host_site = "wordpress"; }
     else if(main_site == "help"){ this.host_site = "askalibrarian"; }
     else if(main_site == "guides"){ this.host_site = "guides"; }
     else{ this.host_site = "askalibrarian"; }
+    if(old_site != this.host_site){
+      this._logToConsole(`'host_site' changed from '${old_site}' to '${this.host_site}'`);
+    }
     
     // determine library
+    let old_library = this.library;
     let lib_code = getLibraryCodeFromUrl(current_url);
-    if(this.debug){ console.log("bulib-footer) selected library code: " + lib_code); }
     this.library = lib_code;
+    if(old_library != this.library){
+      this._logToConsole(`library changed from '${old_library}' to '${this.library}'.`);
+    }
   }
 
   render() {
@@ -117,6 +124,10 @@ class BULFooter extends LitElement {
         </footer>
       </div>
     `;
+  }
+  
+  _logToConsole(message){
+    if(this.debug){ console.log("bulib-footer) " + message); }
   }
 
 }

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -17,7 +17,7 @@
 </head>
 
 <body>
-  <bulib-header curr_url="http://askalibrarian.bu.edu"></bulib-header>
+  <bulib-header debug></bulib-header>
   <br /><hr /><br />
   <bulib-select 
     sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -20,7 +20,7 @@
   <bulib-header debug></bulib-header>
   <br /><hr /><br />
   <bulib-select 
-    sel_title="Select Simulated URL" curr_sel="bu.edu/library/mugar-memorial" 
-    opt_code="wp_urls" tag_name="bulib-header" attr_name="curr_url"
+    sel_title="Select Simulated URL" opt_code="sample_urls" 
+    tag_name="bulib-header" attr_name="curr_url"
   ></bulib-select>
 </body>

--- a/src/header/header.html
+++ b/src/header/header.html
@@ -17,8 +17,17 @@
 </head>
 
 <body>
-  <bulib-header debug></bulib-header>
+  <h1><code>bulib-header</code></h1>
+  <p><em>BU Libraries-branded header for use across our many sites</em></p>
+  <p><small>*includes <code>&lt;bulib-hours&gt;</code></small></p>
+  <p><small>**reacts to the current (or simulated) url (<code>curr_url</code></small>)</p>
+  
   <br /><hr /><br />
+  
+  <bulib-header debug></bulib-header>
+  
+  <br /><hr /><br />
+  
   <bulib-select 
     sel_title="Select Simulated URL" opt_code="sample_urls" 
     tag_name="bulib-header" attr_name="curr_url"

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -1,5 +1,5 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
-import {getLibraryCodeFromUrl} from '../_helpers/lib_info_helper.js';
+import {getSiteCodeFromUrl, getLibraryCodeFromUrl} from '../_helpers/lib_info_helper.js';
 
 /** Reactive/responsive header with custom subsite display, bulib-search integration */
 class BULHeader extends LitElement {
@@ -9,6 +9,7 @@ class BULHeader extends LitElement {
     return {
       // current library (sent to hours) 
       library: {type: String},
+      site: {type: String},
       
       // current url used in testing to determine site
       curr_url: {type: String},
@@ -44,7 +45,7 @@ class BULHeader extends LitElement {
             </ul>
           </div>
           <div class="primary-nav-right phm right">
-            <div class="mvm right"><bulib-hours show_name library="${this.library}" link_class="white-link"></bulib-hours></div>
+            <div class="mvm right"><bulib-hours library="${this.library}" link_class="white-link" verbose></bulib-hours></div>
           </div>
         </div>
       </nav>`;
@@ -55,14 +56,11 @@ class BULHeader extends LitElement {
   /** for development purposes, react to manual changes to `this.curr_url` via _urlUpdated */
   attributeChangedCallback(name, oldValue, newValue){
     super.attributeChangedCallback(name, oldValue, newValue);
-    switch(name){
-      case "curr_url":      this._urlUpdated(); break;
-      default: break;
-    }
+    if(name == "curr_url"){ this._urlUpdated(); }
   }
 
   /** set primary nav 'active' styling */
-  _primaryUpdated(newPrimary){
+  updated(){
     let i, li;
     let siteLinksElem = this.shadowRoot.querySelector("#site-links");
     if(!siteLinksElem){ return; }
@@ -70,35 +68,21 @@ class BULHeader extends LitElement {
     let lsListItems = siteLinksElem.getElementsByTagName("li");
     for(i = 0; i<lsListItems.length; i++) {
       li = lsListItems[i];
-      if((li.id).includes(this.curr_primary)){ li.classList.add("active"); }
+      if((li.id).includes(this.site)){ li.classList.add("active"); }
       else{ li.classList.remove("active"); }
     }
   }
 
   /** set the primary, secondary, and search information according to the currentUrl  */
   _urlUpdated(){
+    let old_site = this.site;
     let currentUrl = (this.curr_url)? this.curr_url : window.location.href;
-
-    let old_primary = this.curr_primary;
-    if(currentUrl.includes("askalibrarian")){
-      this.curr_primary = "help";
-    }else if(currentUrl.includes("buprimo") || currentUrl.includes("exlibrisgroup")){
-      this.curr_primary = "search";
-    }else if(currentUrl.includes(".bu.edu/library")){
-
-      if(currentUrl.includes("/research")){ this.curr_primary = "research"; }
-      else if(currentUrl.includes("/services")){ this.curr_primary = "services"; }
-      else{ this.curr_primary = "about"; }
-      this.library = getLibraryCodeFromUrl(currentUrl);
-      this._logToConsole(`library set to '${this.library}'.`);
-    }else{
-      this.curr_primary = "about";
-    }
+    this.site = getSiteCodeFromUrl(currentUrl, this.debug);
+    this.library = getLibraryCodeFromUrl(currentUrl, this.debug);
 
     // TODO remove and deal with changes in a nicer, more standardized way
-    if(!old_primary || old_primary != this.curr_primary) { 
-      this._primaryUpdated(); 
-      this._logToConsole(`curr_primary: changed from '${old_primary || ""}' to '${this.curr_primary}'.`);
+    if(!old_site || old_site != this.site) { 
+      this._logToConsole(`curr_primary: changed from '${old_site || ""}' to '${this.site}'.`);
     }
   }
   

--- a/src/header/header.js
+++ b/src/header/header.js
@@ -1,4 +1,5 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
+
 import {getSiteCodeFromUrl, getLibraryCodeFromUrl} from '../_helpers/lib_info_helper.js';
 
 /** Reactive/responsive header with custom subsite display, bulib-search integration */
@@ -23,6 +24,7 @@ class BULHeader extends LitElement {
     return html`
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/assets/css/common.min.css">
       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@header-v0.9.6/src/header/header.min.css">
+      <script src="https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libhours-v0.9/src/libhours/libhours.min.js" type="module"></script>
       <style>
         a { text-decoration: none; }
         .right { float:right; }

--- a/src/libhours/libhours.html
+++ b/src/libhours/libhours.html
@@ -29,7 +29,7 @@
   <br /><hr /><br />
   <div class="demo">
     <h3>&lt;bulib-hours <code>verbose</code>&gt;</h3>
-    <bulib-hours verbose></bulib-hours>
+    <bulib-hours verbose debug></bulib-hours>
   </div>
   <br /><hr /><br />
   <bulib-select

--- a/src/libhours/libhours.html
+++ b/src/libhours/libhours.html
@@ -19,19 +19,26 @@
     .demo{ text-align: center; margin: 30px; }
     code { background-color: gainsboro; }  
   </style>
-  <h1><code>&lt;bulib-hours&gt;</code></h1>
-  <p><em>display the current hours of a given library (informed by url)</em></p>
+  
+  <h1><code>bulib-hours</code></h1>
+  <p><em>display the current hours of a given '<code>library</code>'</em></p>
+  
   <br /><hr /><br />
+  
   <div class="demo">
     <h3>&lt;bulib-hours&gt;</h3>
     <bulib-hours></bulib-hours>
   </div>
+  
   <br /><hr /><br />
+  
   <div class="demo">
     <h3>&lt;bulib-hours <code>verbose</code>&gt;</h3>
     <bulib-hours verbose debug></bulib-hours>
   </div>
+  
   <br /><hr /><br />
+  
   <bulib-select
     sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"
     tag_name="bulib-hours" attr_name="library">

--- a/src/libhours/libhours.html
+++ b/src/libhours/libhours.html
@@ -15,10 +15,6 @@
 
 </head>
 <body>
-  <style> 
-    .demo{ text-align: center; margin: 30px; }
-    code { background-color: gainsboro; }  
-  </style>
   
   <h1><code>bulib-hours</code></h1>
   <p><em>display the current hours of a given '<code>library</code>'</em></p>

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -11,14 +11,14 @@ const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
 /** display the hours of operation for a given library */
 class BULibHours extends LitElement {
 
-  createRenderRoot(){ return this;} // don't need 'slot' functionality, so lets use Light DOM
+  // use light DOM to allow for external styling (bulib-header, .white-link)
+  createRenderRoot(){ return this;} 
 
   static get properties() {
     return { 
       library: {type: String}, 
       verbose: {type: Boolean},
       link_class: {type: String},
-      
       debug: {type: Boolean}
     };
   }
@@ -37,30 +37,31 @@ class BULibHours extends LitElement {
     
     // extract relevant pieces from lib_info
     let library_name = lib_info.short || lib_info.name;
-    let hours_url = lib_info.hours_url;
     let lid = lib_info.libcal_lid;
     if(library_name.includes("BU Librar")){ library_name = "Mugar Library"; }
 
     // prepare templates
     this._logToConsole(`rendering hours for ${library_name} (code:'${libCode}').`);
     let hours_loading = html`
-      <span id="hours-display" style="display: inline-block">
-        ${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}</span>`;
-    let see_all_link = html`<small><a href="${all_lib_hours_url}" class=${this.link_class}>see all location hours</a></small>`;
+      <span id="hours-display" class="inline" aria-label="today's hours for ${library_name}">
+        ${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}
+      </span>`;
+    let clock_icon = html`<img alt="clock-icon" id="clock-icon" src="https://material.io/tools/icons/static/icons/baseline-schedule-24px.svg">`;
+    let main_display = html`<strong>${library_name}:</strong>&nbsp;${hours_loading}`;
 
     return html`
       <style> 
         :host { color: white; } 
         .libhours { text-align: center; }
+        .txtv { display: flex; align-items: center; text-align: center; }
       </style>
       <div class="libhours">
-        <div id="hours-top">
-          ${this.verbose
-            ? html`<strong>${library_name}:</strong> ${hours_loading}` 
-            : html`<a class="${this.link_class}" href="${hours_url}">hours today</a> <strong>${hours_loading}</strong>`
-          }
-        </div>
-        <div id="hours-bottom">${this.verbose? html`${see_all_link}` : html`` }</div>
+        ${this.verbose 
+          ? html` <div id="hours-top">${main_display}</div>
+                  <div id="hours-btm">
+                    <small><a href="${all_lib_hours_url}" class=${this.link_class}>see all location hours</a></small>
+                  </div>`
+          : html`<div class="txtv center">${clock_icon}&nbsp;&nbsp;${main_display}</div>`}
       </div>
       `;
   }

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -11,7 +11,7 @@ const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
 /** display the hours of operation for a given library */
 class BULibHours extends LitElement {
 
-  // createRenderRoot(){ return this;} // don't need 'slot' functionality, so lets use Light DOM
+  createRenderRoot(){ return this;} // don't need 'slot' functionality, so lets use Light DOM
 
   static get properties() {
     return { 
@@ -48,7 +48,7 @@ class BULibHours extends LitElement {
 
     return html`
       <style> 
-        // :host { color: white; }
+        :host { color: white; } 
         .libhours { text-align: center; }
         .gold { color: gold; }
       </style>

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -43,14 +43,15 @@ class BULibHours extends LitElement {
 
     // prepare templates
     this._logToConsole(`rendering hours for ${library_name} (code:'${libCode}').`);
-    let hours_loading = html`<span id="hours-display">${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}</span>`;
+    let hours_loading = html`
+      <span id="hours-display" style="display: inline-block">
+        ${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}</span>`;
     let see_all_link = html`<small><a href="${all_lib_hours_url}" class=${this.link_class}>see all location hours</a></small>`;
 
     return html`
       <style> 
         :host { color: white; } 
         .libhours { text-align: center; }
-        .gold { color: gold; }
       </style>
       <div class="libhours">
         <div id="hours-top">

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -43,9 +43,8 @@ class BULibHours extends LitElement {
 
     // prepare templates
     this._logToConsole(`rendering hours for ${library_name} (code:'${libCode}').`);
-    let hours_loading = html`<em id="hours-display" class="gold">${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}</em>`;
-    let hours_link = html`<a title="see full hours for ${library_name}" class="${this.link_class}" href="${hours_url}">hours</a>`;
-    let see_all_link = html`<small><a href="${all_lib_hours_url}" class=${this.link_class}>(all location hours)</a></small>`;
+    let hours_loading = html`<span id="hours-display">${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}</span>`;
+    let see_all_link = html`<small><a href="${all_lib_hours_url}" class=${this.link_class}>see all location hours</a></small>`;
 
     return html`
       <style> 
@@ -56,11 +55,11 @@ class BULibHours extends LitElement {
       <div class="libhours">
         <div id="hours-top">
           ${this.verbose
-            ? html`<strong>${library_name} ${hours_link}</strong>` 
+            ? html`<strong>${library_name}:</strong> ${hours_loading}` 
             : html`<a class="${this.link_class}" href="${hours_url}">hours today</a> <strong>${hours_loading}</strong>`
           }
         </div>
-        <div id="hours-bottom">${this.verbose? html`${hours_loading} ${see_all_link}` : html`` }</div>
+        <div id="hours-bottom">${this.verbose? html`${see_all_link}` : html`` }</div>
       </div>
       `;
   }

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -11,7 +11,7 @@ const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
 /** display the hours of operation for a given library */
 class BULibHours extends LitElement {
 
-  createRenderRoot(){ return this;} // don't need 'slot' functionality, so lets use Light DOM
+  // createRenderRoot(){ return this;} // don't need 'slot' functionality, so lets use Light DOM
 
   static get properties() {
     return { 
@@ -48,7 +48,7 @@ class BULibHours extends LitElement {
 
     return html`
       <style> 
-        :host { color: white; } 
+        // :host { color: white; }
         .libhours { text-align: center; }
         .gold { color: gold; }
       </style>

--- a/src/libsel/libsel.js
+++ b/src/libsel/libsel.js
@@ -1,8 +1,6 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryInfoFromCode} from 'https://cdn.jsdelivr.net/gh/bulib/bulib-wc@libsel-v0.8/src/_helpers/lib_info_helper.js?module';
 
-const debug = false;
-const change_url_on_select = true;
 
 const lsLibraryCodes = ["mugar-memorial","african-studies","medlib","astronomy","lawlibrary","hgar","music","pardee","pickering","theology","sel","stone"];
 
@@ -36,7 +34,11 @@ class BULibSel extends LitElement {
       /** library code referring to the library whose hours we want to display */
       library: {type: String, notify:true},
       /** current url (potentially) used for automatically setting the library */
-      curr_url: {type: String, notify:true}
+      curr_url: {type: String, notify:true},
+      
+      /** log to console */
+      debug: {type:Boolean},
+      prevent_action: {type:Boolean}
     };
   }
 
@@ -47,14 +49,6 @@ class BULibSel extends LitElement {
       <select id="libsel-select" @input=${(e) => this._SelectionChanged(e)}}>
         ${lsLibraryOptions.map((o) => html`<option value="${o.value}">${o.name}</option>`)}
       </select>`;
-  }
-
-  /** once html is on the page, add classes based on current values */
-  updated(){
-
-    let libsel_elem = document.getElementById("libsel-select");
-    //TODO ensule the current selection is displayed in the dropdown
-    //libsel_elem.selected = this.library;
   }
 
   /** update current properties to inform what to display */
@@ -76,8 +70,8 @@ class BULibSel extends LitElement {
     this.library = value;
     let before = window.location.href;
     let url_new = getLibraryInfoFromCode(value)["website"] || `http://bu.edu/library/${value}/`;
-    if(debug){ console.log(`bulib-libsel) '<libsel>.curr_url' changing from ${before} to ${url_new}...`); }
-    if(change_url_on_select){ window.location.href = url_new; }
+    if(this.debug){ console.log(`bulib-libsel) '<libsel>.curr_url' changing from ${before} to ${url_new}...`); }
+    if(!this.prevent_action){ window.location.href = url_new; }
   }
 
 }

--- a/src/locoso/locoso.html
+++ b/src/locoso/locoso.html
@@ -15,7 +15,7 @@
 
   </head>
   <body>
-    <bulib-locoso library="astronomy"></bulib-locoso>
+    <bulib-locoso library="astronomy" debug></bulib-locoso>
     <br /><hr /><br />
     <bulib-select 
       sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"

--- a/src/locoso/locoso.html
+++ b/src/locoso/locoso.html
@@ -15,8 +15,20 @@
 
   </head>
   <body>
-    <bulib-locoso library="astronomy" debug></bulib-locoso>
+    <h1><code>bulib-locoso</code></h1>
+    <p>
+      <em>
+        Display <strong>LO</strong>cation, <strong>CO</strong>ntact, and <strong>SO</strong>cial media 
+        information depending on the '<code>library</code>'
+      </em>
+    </p>
+    
     <br /><hr /><br />
+    
+    <bulib-locoso library="astronomy" debug></bulib-locoso>
+    
+    <br /><hr /><br />
+    
     <bulib-select 
       sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"
       tag_name="bulib-locoso" attr_name="library">

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -1,8 +1,6 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
 
-const debug = false;
-
 /**
  * display the *LO*cation, *CO*ntact, and *SO*cial media information for
  *    a given library within the Boston Universities System.
@@ -19,13 +17,15 @@ class BULocoso extends LitElement {
       /** optional additional class added to each link in the rendered HTML */
       link_class: {type: String},
       /** current library code used as the key to swap between locoso data entries */
-      library: {type: String, notify:true}
+      library: {type: String, notify:true},
+      
+      debug: {type: Boolean}
     };
   }
 
   render() {
     let myLocoso = getLibraryInfoFromCode(this.library) || {};
-    if(debug){ console.log("bulib-locoso) myLocoso: "); console.log(myLocoso); }
+    this._logToConsole("raw lib_data from lib_info_helper: \n" + JSON.stringify(myLocoso));
 
     let lib_name = myLocoso["name"] || "BU Libraries";
     let address = myLocoso["address"] || ["771 Commonwealth Avenue","Boston, MA 02215"];
@@ -114,6 +114,7 @@ class BULocoso extends LitElement {
     if(rawContacts["fax"]){
       contacts.push( {"text":"fax", "url":"fax:"+rawContacts["fax"], "val":rawContacts["fax"] } );
     }
+    this._logToConsole(`${contacts.length.toString()} items found for 'contacts'.`);
     return contacts;
   }
 
@@ -137,7 +138,12 @@ class BULocoso extends LitElement {
     if(rawSocial["tumblr"]){
       social.push( {"text":"tumblr", "url":"http://tumblr."+rawSocial["tumblr"]+".com/"} );
     }
+    this._logToConsole(`${social.length.toString()} items found for 'social'.`);
     return social;
+  }
+  
+  _logToConsole(message){
+    if(this.debug){ console.log("bulib-locoso) " + message); }
   }
 
 }

--- a/src/search/search.html
+++ b/src/search/search.html
@@ -16,6 +16,11 @@
   </head>
   <body>
     
+    <h1><code>bulib-search</code></h1>
+    <p><em>Generic 'search' box with customizable '<code>str_selected</code>', '<code>str_options</code>'</em></p>
+
+    <br /><hr /><br />
+
     <label>Empty (active)</label>
     <bulib-search debug></bulib-search>
     <br /><br />
@@ -38,6 +43,7 @@
     <br /><br />
     
     <br /><hr /><br />
+    
     <bulib-select
       sel_title="Select Search Source" curr_sel="primo" opt_code="search_options"
       tag_name="bulib-search" attr_name="str_selected" debug prevent_action>

--- a/src/search/search.html
+++ b/src/search/search.html
@@ -17,7 +17,7 @@
   <body>
     
     <label>Empty</label>
-    <bulib-search></bulib-search>
+    <bulib-search debug prevent_action></bulib-search>
     <br /><br />
     
     <label>One Option, no Default</label>
@@ -25,17 +25,18 @@
     <br /><br />
   
     <label>Options, no Default</label>
-    <bulib-search id="options-no-default" str_options="primo industries wp"></bulib-search>
+    <bulib-search id="options-no-default" str_options="primo industries wp help" debug prevent_action></bulib-search>
     <br /><br />
     
     <label>Options, with Default</label>
-    <bulib-search name="options, with default" str_options="primo industries wp" str_selected="industries"></bulib-search>
+    <bulib-search name="options, with default" str_options="primo industries wp" 
+                  str_selected="industries" debug prevent_action></bulib-search>
     <br /><br />
     
     <br /><hr /><br />
     <bulib-select
       sel_title="Select Search Source" curr_sel="primo" opt_code="search_options"
-      tag_name="bulib-search" attr_name="str_selected">
+      tag_name="bulib-search" attr_name="str_selected" debug prevent_action>
     </bulib-select>
   </body>
 </html>

--- a/src/search/search.html
+++ b/src/search/search.html
@@ -40,8 +40,7 @@
     <label>Options, with Default</label>
     <bulib-search name="options, with default" str_options="primo industries wp" 
                   str_selected="industries" debug prevent_action></bulib-search>
-    <br /><br />
-    
+
     <br /><hr /><br />
     
     <bulib-select

--- a/src/search/search.html
+++ b/src/search/search.html
@@ -16,7 +16,11 @@
   </head>
   <body>
     
-    <label>Empty</label>
+    <label>Empty (active)</label>
+    <bulib-search debug></bulib-search>
+    <br /><br />
+    
+    <label>Empty (inactive)</label>
     <bulib-search debug prevent_action></bulib-search>
     <br /><br />
     

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -4,7 +4,7 @@ const default_to_just_primo = true;
 
 /** data on the overall search sources we have available to search on */
 export const search_options = [
-  {"value":"primo",     "name":"BU Libraries Search",      "placeholder": "Search library resources",     "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?vid=BUinstitution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&query=any,contains,"},
+  {"value":"primo",     "name":"BU Libraries Search",      "placeholder": "Search library resources",     "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?vid=BU&institution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&query=any,contains,"},
   {"value":"industries","name":"Industry Survey Locator",  "placeholder": "Search for industry surveys",  "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?vid=ISL&institution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&query=any,contains,"},
   {"value":"worldcat",  "name":"OCLC WorldCat",            "placeholder": "BU Libraries Search",          "domain":"https://bu.on.worldcat.org/search?queryString="},
   {"value":"wp",        "name":"Boston University Site",   "placeholder": "Search library info/services", "domain":"https://search.bu.edu/?site=www.bu.edu%2Flibrary&q="},

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -4,8 +4,8 @@ const default_to_just_primo = true;
 
 /** data on the overall search sources we have available to search on */
 export const search_options = [
-  {"value":"primo",     "name":"BU Libraries Search",      "placeholder": "Search library resources",     "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?institution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&vid=BU&query=any,contains,"},
-  {"value":"industries","name":"Industry Survey Locator",  "placeholder": "Search for industry surveys",  "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?institution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&vid=ISL&query=any,contains,"},
+  {"value":"primo",     "name":"BU Libraries Search",      "placeholder": "Search library resources",     "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?vid=BUinstitution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&query=any,contains,"},
+  {"value":"industries","name":"Industry Survey Locator",  "placeholder": "Search for industry surveys",  "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?vid=ISL&institution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&query=any,contains,"},
   {"value":"worldcat",  "name":"OCLC WorldCat",            "placeholder": "BU Libraries Search",          "domain":"https://bu.on.worldcat.org/search?queryString="},
   {"value":"wp",        "name":"Boston University Site",   "placeholder": "Search library info/services", "domain":"https://search.bu.edu/?site=www.bu.edu%2Flibrary&q="},
   // {"value":"directory", "name":"Staff Directory",          "placeholder": "Search for people at BU",      "domain":"https://www.bu.edu/phpbin/directory/?q="},
@@ -53,7 +53,7 @@ class BULSearch extends LitElement {
       
       /* configurable defaults for logging, dropdown, submission action */
       debug: {type: Boolean},
-      prevent_submit: {type: Boolean}
+      prevent_action: {type: Boolean}
     };
   }
 
@@ -148,8 +148,9 @@ class BULSearch extends LitElement {
     let domain = option["domain"] || "";
 
     //conditionally log and/or perform search
-    this._logToConsole(`searching '${site}' for query: '${query}' on domain: '${domain}'...`);
-    if(!this.prevent_submit){ window.location = domain + encodeURIComponent(query); }
+    let domain_to_print = domain.length > 80? domain.substring(0,80) + "..." : domain;
+    this._logToConsole(`searching '${site}' for query: '${query}' on domain: '${domain_to_print}'`);
+    if(!this.prevent_action === true){ window.location = domain + encodeURIComponent(query); }
   }
   
   /** call this._doSearch() if key that user pressed is ENTER */ 

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -1,10 +1,6 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 const ENTER_KEY_VALUE = 13;
-
-/* configurable defaults for logging, dropdown, submission action */
-const debug = true;
 const default_to_just_primo = true;
-const search_on_submit = true;
 
 /** data on the overall search sources we have available to search on */
 export const search_options = [
@@ -53,12 +49,22 @@ class BULSearch extends LitElement {
       /** search sources included in the dropdown (defaulted to all) */
       str_options: {type: String},
       /** classes added to the search <button> */
-      search_btn_classes: {type: String}
+      search_btn_classes: {type: String},
+      
+      /* configurable defaults for logging, dropdown, submission action */
+      debug: {type: Boolean},
+      prevent_submit: {type: Boolean}
     };
   }
 
   /** don't need 'slot' functionality, so lets use Light DOM */
   createRenderRoot(){ return this; }
+  
+  /** for development purposes, react to manual changes to `this.curr_url` via _urlUpdated */
+  attributeChangedCallback(name, oldValue, newValue){
+    super.attributeChangedCallback(name, oldValue, newValue);
+    this._logToConsole(`${name} changed from ${oldValue} to ${newValue}.`);
+  }
 
   render() {
     this._initSelectedOptions();
@@ -142,13 +148,17 @@ class BULSearch extends LitElement {
     let domain = option["domain"] || "";
 
     //conditionally log and/or perform search
-    if(debug){ console.log(`bulib-search) searching '${site}' for query: '${query}' on domain: '${domain}'...`); }
-    if(search_on_submit){ window.location = domain + encodeURIComponent(query); }
+    this._logToConsole(`searching '${site}' for query: '${query}' on domain: '${domain}'...`);
+    if(!this.prevent_submit){ window.location = domain + encodeURIComponent(query); }
   }
   
   /** call this._doSearch() if key that user pressed is ENTER */ 
   _handleSearchEnter(event){
     if(event.keyCode && event.keyCode === ENTER_KEY_VALUE){ this._doSearch(); }
+  }
+  
+  _logToConsole = function(message){
+    if(this.debug){ console.log("bulib-search) " + message); }
   }
 
 }

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -1,7 +1,6 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {search_options} from '../search/search.js';
 
-const debug = false;
 const libraries =  [
   {"value":"mugar-memorial","name":"SELECT LIBRARY"},
   {"value":"mugar-memorial","name":"Mugar Memorial"},
@@ -47,22 +46,20 @@ const opt_map = {
 
 class BULSelect extends LitElement{
 
-  constructor(){
-    super();
-  }
-
   static get properties(){
     return {
+      /** title displayed next to the dropdown */
+      sel_title: {type: String},
       /** currently selected item code (referring to values in option map) */
       curr_sel: {type: String, notify:true},
       /** the key for which option map to use for populating the dropdown */
       opt_code: {type: String},
-      /** title displayed next to the dropdown */
-      sel_title: {type: String},
       /** the name of the tag which we desire to update (e.g. <bulib-locoso> = 'bulib-locoso') */
       tag_name: {type: String},
       /** the attribute of that tag which needs to be changed */
-      attr_name: {type: String}
+      attr_name: {type: String},
+      /* controls logging to the console */
+      debug: {type:Boolean}
     };
   }
 
@@ -91,14 +88,14 @@ class BULSelect extends LitElement{
       element.setAttribute(this.attr_name, current);
       after = element.getAttribute(this.attr_name);
       
-      if(debug && before != after){ 
+      if(this.debug && before != after){ 
         let id_string = "?";
         if(element){
           if(element.id){ id_string = "#"+element.id; }
           if(element.hasAttribute("name")){ id_string = "'" + element.getAttribute("name") + "'"; }
         } 
         
-        if(debug){ console.log(`bulib-select) changed '<${this.tag_name}>[${id_string}].${this.attr_name}' from '${before}' to '${after}'.`); }
+        if(this.debug){ console.log(`bulib-select) changed '<${this.tag_name}>[${id_string}].${this.attr_name}' from '${before}' to '${after}'.`); }
       }
     }
   }

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -16,7 +16,7 @@ const libraries =  [
   {"value":"sel","name":"Science and Engineering"},
   {"value":"stone","name":"Stone Science"}
 ];
-const wp_urls = [
+const sample_urls = [
   {"name":"SELECT URL",     "value":"www.bu.edu/library"},
   {"name":"Primo Search",   "value":"buprimo.hosted.exlibrisgroup.com/primo-explore/search"},
   {"name":"Guides",         "value":"www.bu.edu/library/research/guides/course-guides/"},
@@ -39,7 +39,7 @@ const sites = [
 ];
 const opt_map = {
   "libraries":libraries,
-  "wp_urls":wp_urls,
+  "sample_urls":sample_urls,
   "search_options":search_options,
   "sites":sites
 };

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -31,17 +31,10 @@ const sample_urls = [
   {"name":"Stone Library",  "value":"http://www.bu.edu/library/stone-science/"},
   {"name":"Help",           "value":"askalibrarian.bu.edu/"}
 ];
-const sites = [
-  {"name":"SELECT A SITE",  "value":"askalibrarian"},
-  {"name":"Ask a Librarian","value":"askalibrarian"},
-  {"name":"LibGuides",      "value":"guides"},
-  {"name":"Wordpress",      "value":"wordpress"}
-];
 const opt_map = {
   "libraries":libraries,
   "sample_urls":sample_urls,
-  "search_options":search_options,
-  "sites":sites
+  "search_options":search_options
 };
 
 class BULSelect extends LitElement{


### PR DESCRIPTION
### Background
- in development, i've been using a few variables on each component to be able to turn on logging and turn off various core functionality (e.g. `bulib-search` redirecting to another page)
- until recently i've been doing it in the file itself and outside of the component, meaning i have to do a code change to make those change.
- moving the variable into a `property` allows the end user to change the behavior on any page they appear on within "inspect element" 

### Description of Changes
- move `debug`-oriented variables from file-level `const` variables into `static get properties()`
- rename and reorient some of them (e.g. `bulib_search.prevent_action`) to adjust default
- make footer interactions match up with new 'header' affordances.
- change the defaults for all of the example pages to `debug` by default

### Screenshots

**header**: _header, libhours, lib_info_helper_
![bulib-header with `debug` added to each component](https://user-images.githubusercontent.com/5565284/55196551-1fa6bf80-5186-11e9-8a57-cc910b8990c4.png)

**footer**: _footer, locoso_
![bulib-footer with `debug` added to each component](https://user-images.githubusercontent.com/5565284/55196748-b2dff500-5186-11e9-9b60-7da560055c61.png)


**search**: _search, select_
![bulib-search with `debug` and `prevent_default`](https://user-images.githubusercontent.com/5565284/55196138-dace5900-5184-11e9-9f1b-2d7525ea0fb8.png)

