### PR TITLE
WEB-120: initial changes to libhours with additions to footer

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -31,6 +31,7 @@
 /* text */
 .txtl { text-align: left; }
 .txtc { text-align: center; }
+.txtv { vertical-align: middle; }
 .big-text { font-size: 110%; }
 
 

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -107,11 +107,13 @@ class BULFooter extends LitElement {
                 </a>
                 <br /><br />
                 <small>
-                  <a class="white-link" target="_blank" title="Copyright" href="https://www.bu.edu/copyright">&copy; Copyright ${new Date().getFullYear()}</a>
+                  <a class="white-link" target="_blank" title="Copyright" 
+                     href="https://www.bu.edu/copyright">&copy; Copyright ${new Date().getFullYear()}</a>
                 </small>
                 <br />
                 <small>
-                  <a class="white-link" target="_blank" title="Privacy Statement" href="https://www.bu.edu/policies/information-security-home/digital-privacy-statement/">Privacy Statement</a>
+                  <a class="white-link" target="_blank" title="Privacy Statement" 
+                     href="https://www.bu.edu/policies/information-security-home/digital-privacy-statement/">Privacy Statement</a>
                 </small>
                 <br /><br />
               </div>
@@ -128,7 +130,7 @@ class BULFooter extends LitElement {
           </div>
           <div class="ftr-right">
             <div id="ftr-locoso">
-              <bulib-locoso library="${this.library}" link_class="white-link"></bulib-locoso>
+              <bulib-locoso library="${this.library}" link_class="white-link" debug></bulib-locoso>
             </div>
           </div>
         </footer>

--- a/src/libhours/libhours.html
+++ b/src/libhours/libhours.html
@@ -29,14 +29,21 @@
   <br /><hr /><br />
   
   <div class="demo">
-    <h3>&lt;bulib-hours <code>verbose</code>&gt;</h3>
-    <bulib-hours verbose debug></bulib-hours>
+    <h3>&lt;bulib-hours <code>long</code>&gt;</h3>
+    <bulib-hours long debug></bulib-hours>
+  </div>
+  
+  <br /><hr /><br />
+  
+  <div class="demo">
+    <h3>&lt;bulib-hours <code>short</code>&gt;</h3>
+    <bulib-hours short debug></bulib-hours>
   </div>
   
   <br /><hr /><br />
   
   <bulib-select
-    sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"
+    sel_title="Select Library" opt_code="libraries"
     tag_name="bulib-hours" attr_name="library">
   </bulib-select>
 </body>

--- a/src/libhours/libhours.js
+++ b/src/libhours/libhours.js
@@ -3,7 +3,7 @@ import {until} from 'https://unpkg.com/lit-html@1.0.0/directives/until.js?module
 
 import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
 
-const all_lib_hours_url = "http://www.bu.edu/library/about/hours/";
+const all_lib_hours_url = "https://www.bu.edu/library/about/hours/";
 const cors_anywhere_prefix = 'https://cors-anywhere.herokuapp.com/';
 const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
 
@@ -12,12 +12,15 @@ const libcal_hours_api_url = 'https://api3.libcal.com/api_hours_today.php';
 class BULibHours extends LitElement {
 
   // use light DOM to allow for external styling (bulib-header, .white-link)
-  createRenderRoot(){ return this;} 
+  createRenderRoot(){ return this; } 
 
   static get properties() {
     return { 
       library: {type: String}, 
-      verbose: {type: Boolean},
+      
+      short:{type: Boolean},
+      long: {type: Boolean},
+      
       link_class: {type: String},
       debug: {type: Boolean}
     };
@@ -40,30 +43,42 @@ class BULibHours extends LitElement {
     let lid = lib_info.libcal_lid;
     if(library_name.includes("BU Librar")){ library_name = "Mugar Library"; }
 
-    // prepare templates
+    // prepare parts
     this._logToConsole(`rendering hours for ${library_name} (code:'${libCode}').`);
     let hours_loading = html`
       <span id="hours-display" class="inline" aria-label="today's hours for ${library_name}">
         ${until(this._fetchHoursData(lid), html`<small> loading hours...</small>`)}
       </span>`;
     let clock_icon = html`<img alt="clock-icon" id="clock-icon" src="https://material.io/tools/icons/static/icons/baseline-schedule-24px.svg">`;
-    let main_display = html`<strong>${library_name}:</strong>&nbsp;${hours_loading}`;
+    
+    // establish variants 
+    let none_display = html``;
+    let small_display = html`<a title="today's hours for ${library_name}" href="${all_lib_hours_url}" class="${this.link_class}">${hours_loading}</a>`;
+    let medium_display = html`<div class="txtv center">${clock_icon}&nbsp;&nbsp;<strong>${library_name}:</strong>&nbsp;${hours_loading}</div>`;
+    let large_display = html`
+      <div id="hours-top">
+        <strong>${library_name}:</strong>&nbsp;${hours_loading}</div>
+      </div>
+      <div id="hours-btm">
+        <small><a href="${all_lib_hours_url}" class="${this.link_class}">see all location hours</a></small>
+      </div>
+    `;
+    
+    // select between the variants based on the available data and settings
+    let libhours_display;
+    if(!lid){ libhours_display = none_display; }
+    if(this.short){ libhours_display = small_display; }
+    else if(this.long){  libhours_display = large_display; }
+    else{ libhours_display = medium_display; }
 
     return html`
       <style> 
         :host { color: white; } 
-        .libhours { text-align: center; }
+        a > span { text-decoration: underline; }
         .txtv { display: flex; align-items: center; text-align: center; }
       </style>
-      <div class="libhours">
-        ${this.verbose 
-          ? html` <div id="hours-top">${main_display}</div>
-                  <div id="hours-btm">
-                    <small><a href="${all_lib_hours_url}" class=${this.link_class}>see all location hours</a></small>
-                  </div>`
-          : html`<div class="txtv center">${clock_icon}&nbsp;&nbsp;${main_display}</div>`}
-      </div>
-      `;
+      <div class="libhours">${libhours_display}</div>
+    `;
   }
   
   _logToConsole = function(message){

--- a/src/locoso/locoso.html
+++ b/src/locoso/locoso.html
@@ -26,7 +26,7 @@
     <br /><hr /><br />
     
     <div>
-      <bulib-locoso library="astronomy" debug></bulib-locoso>
+      <bulib-locoso debug></bulib-locoso>
     </div>
     
     <br /><hr /><br />

--- a/src/locoso/locoso.html
+++ b/src/locoso/locoso.html
@@ -32,7 +32,7 @@
     <br /><hr /><br />
     
     <bulib-select 
-      sel_title="Select Library" curr_sel="astronomy" opt_code="libraries"
+      sel_title="Select Library" opt_code="libraries"
       tag_name="bulib-locoso" attr_name="library">
     </bulib-select>
   </body>

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -38,7 +38,7 @@ class BULocoso extends LitElement {
     let raw_social = myLocoso["social"] || {};
     let social = this._prepareSocial(raw_social);
     
-    let include_libhours = this.library != "help";
+    let include_libhours = this.library && this.library != "help";
     this._logToConsole("lib_name: " + lib_name + ", include_libhours: " + include_libhours);
     
     let socialDisplay;
@@ -54,6 +54,7 @@ class BULocoso extends LitElement {
         </ul>
       `;
     }
+    
     return html`
       <style>
         /* layout and responsiveness */
@@ -73,8 +74,8 @@ class BULocoso extends LitElement {
           <div class="txtv">
             <h3 class="inline">Visit Us</h3>&nbsp;&nbsp;&nbsp;
             ${include_libhours 
-                ? html`-&nbsp;&nbsp;<bulib-hours class="inline" link_class="${this.link_class}" library="${this.library}" short></bulib-hours>` 
-                : html``
+              ? html`-&nbsp;&nbsp;<bulib-hours class="inline" link_class="${this.link_class}" library="${this.library}" short></bulib-hours>` 
+              : html``
             }
           </div>
           <ol class="no-bullet" aria-label="address">

--- a/src/locoso/locoso.js
+++ b/src/locoso/locoso.js
@@ -1,5 +1,6 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
 import {getLibraryInfoFromCode} from '../_helpers/lib_info_helper.js';
+import '../libhours/libhours.js';
 
 /**
  * display the *LO*cation, *CO*ntact, and *SO*cial media information for
@@ -37,6 +38,9 @@ class BULocoso extends LitElement {
     let raw_social = myLocoso["social"] || {};
     let social = this._prepareSocial(raw_social);
     
+    let include_libhours = this.library != "help";
+    this._logToConsole("lib_name: " + lib_name + ", include_libhours: " + include_libhours);
+    
     let socialDisplay;
     if(social.length < 1){ socialDisplay = html``; }
     else{
@@ -66,7 +70,13 @@ class BULocoso extends LitElement {
       </style>
       <div class="locoso-wrapper">
         <div class="locoso-left">
-          <h3 class="inline">Visit Us</h3>&nbsp;
+          <div class="txtv">
+            <h3 class="inline">Visit Us</h3>&nbsp;&nbsp;&nbsp;
+            ${include_libhours 
+                ? html`-&nbsp;&nbsp;<bulib-hours class="inline" link_class="${this.link_class}" library="${this.library}" short></bulib-hours>` 
+                : html``
+            }
+          </div>
           <ol class="no-bullet" aria-label="address">
             <li>${lib_name}</li>
             ${address.map((l) => html`<li>${l}</li>`)}

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -2,7 +2,7 @@ import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit
 import {search_options} from '../search/search.js';
 
 const libraries =  [
-  {"value":"mugar-memorial","name":"SELECT LIBRARY"},
+  {"value":"help","name":"SELECT LIBRARY"},
   {"value":"mugar-memorial","name":"Mugar Memorial"},
   {"value":"african-studies","name":"African Studies"},
   {"value":"medlib", "name":"Alumni Medical"},
@@ -89,10 +89,8 @@ class BULSelect extends LitElement{
     }
     
     this._logToConsole("num elements: " + elements.length.toString());
-    console.log(elements);
     
     let i, before, after, element;
-    
     for(i=0; i<elements.length; i++){
       element = elements[i];
       before = element.getAttribute(this.attr_name);


### PR DESCRIPTION
 Jira Ticket: [WEB-120](https://bulibrary.atlassian.net/browse/WEB-120)

### Screenshots
![bulib-footer with stone library selected](https://user-images.githubusercontent.com/5565284/57553630-19872f80-733d-11e9-8b77-85c273b2d5fa.png)

### Description of Changes
- [x] `libhours`: add `short` attribute option for an hours-only-as-a-link display
- [x] `libhours`: change `verbose` data attribute to `long`
- [x] `locoso`: add `<bulib-hours>` (conditionally) to locoso
- [ ] increment versions (publish) and update usages