### PR TITLE
WEB-58: footer - Add 'primo' host_site option to bulib-footer sitemap

### DIFF
--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -126,7 +126,7 @@ export function getSiteCodeFromUrl(url, debug=false, defSiteCode="help"){
   else if(url.includes("/disc/") || url.includes("/dioa")){ site_code ="services"; }
   else if(url.includes("open.bu") || url.includes("archives")){ site_code = "collections"; }
   else if(url.includes("guides")){ site_code = "guides" }
-  else if(url.includes("buprimo") || url.includes("exlibrisgroup")){ site_code = "research"/*"search"*/; }
+  else if(url.includes("buprimo") || url.includes("exlibrisgroup")){ site_code = "search"; }
   
   else if(url.includes(".bu.edu/library")){
     if(url.includes("/research")){ site_code = "research"; }

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -1,9 +1,9 @@
 import {LitElement, html} from 'https://unpkg.com/@polymer/lit-element@0.6.4/lit-element.js?module';
-import {getSiteCodeFromUrl, getLibraryCodeFromUrl} from 'https://cdn.jsdelivr.net/gh/bulib/bulib-wc@locoso-v1.5/src/_helpers/lib_info_helper.js';
+import {getSiteCodeFromUrl, getLibraryCodeFromUrl} from 'https://cdn.jsdelivr.net/gh/bulib/bulib-wc@footer-v2.7.2/src/_helpers/lib_info_helper.js';
 
 /** stored values for the sitemap */
 const sitemap_values = {
-  "wordpress":{
+    "wordpress":{
     "header":"Boston University Libraries",
     "links":[
       {"title":"InterLibrary Borrowing","href":"/library/services/ill/"},
@@ -30,6 +30,14 @@ const sitemap_values = {
       {"title":"How-To Guides",               "href":"https://www.bu.edu/library/help/how-to/"},
       {"title":"Make a Research Appointment", "href":"https://www.bu.edu/library/services/reference/appointments/"}
     ]
+  },"primo":{
+    "header":"BU Libraries Search",
+    "links":[
+      {"title":"Browse",          "href":"/primo-explore/browse?vid=BU"},
+      {"title":"Search Help",     "href":"https://www.bu.edu/library/help/bu-libraries-search/"},
+      {"title":"Databases List",  "href":"https://library.bu.edu/az.php"},
+      {"title":"What's New",      "href":"https://www.bu.edu/library/help/bu-libraries-search/new-bu-libraries-search-features/"}
+    ]
   }
 };
 
@@ -55,7 +63,7 @@ class BULFooter extends LitElement {
 
   /** upon the element's first connection to the DOM, get the url and use it to determine $this.library */
   updated(){
-    let current_url = this.curr_url? this.curr_url : window.location.href;
+    let current_url = !!this.curr_url? this.curr_url : window.location.href;
     
     // determine site
     let old_site = this.host_site;
@@ -63,6 +71,7 @@ class BULFooter extends LitElement {
     if(["about","research","services"].includes(main_site)){ this.host_site = "wordpress"; }
     else if(main_site == "help"){ this.host_site = "askalibrarian"; }
     else if(main_site == "guides"){ this.host_site = "guides"; }
+    else if(main_site == "search" || main_site == "primo"){ this.host_site = "primo"; }
     else{ this.host_site = "askalibrarian"; }
     if(old_site != this.host_site){
       this._logToConsole(`'host_site' changed from '${old_site}' to '${this.host_site}'`);


### PR DESCRIPTION
add 'host_site' entry and adjust lib_info_helper to send 'search' site_code