### PR TITLE
WEB-58: Adjust 'bulib-footer' sitemap, _helper condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.0.72",
+  "version": "0.0.77",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.0.72",
+  "version": "0.0.77",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/src/_helpers/lib_info_helper.js
+++ b/src/_helpers/lib_info_helper.js
@@ -127,8 +127,7 @@ export function getSiteCodeFromUrl(url, debug=INFO_HELPER_DEBUG, defSiteCode="he
   else if(url.includes("/disc/") || url.includes("/dioa")){ site_code ="services"; }
   else if(url.includes("open.bu") || url.includes("archives")){ site_code = "collections"; }
   else if(url.includes("guides")){ site_code = "guides" }
-  else if(url.includes("buprimo") || url.includes("exlibrisgroup")){ site_code = "search"; }
-  
+  else if(url.includes("buprimo") || url.includes("exlibrisgroup") || url.includes("primo-explore")){ site_code = "search"; }
   else if(url.includes(".bu.edu/library")){
     if(url.includes("/research")){ site_code = "research"; }
     else if(url.includes("/services")){ site_code = "services"; }


### PR DESCRIPTION
Jira Ticket: [WEB-58](https://bulibrary.atlassian.net/browse/WEB-58)

### Description of Changes
- update list of `primo` links in `bulib-footer` 
- update condition for when `search` is determined to begin with

_note: also includes the following commit_:
```a34302e (origin/WEB-180) WEB-183: update 'primo' bulib-footer 'links'```