### PR TITLE
WEB-194: [bugfix] Resolve 403 Errors on select '/library' searches

### DIFF
--- a/scripts/bundle_css.sh
+++ b/scripts/bundle_css.sh
@@ -19,9 +19,6 @@ cp ./sites/libanswers/libanswers.css ./dist/libanswers.css
 cp ./sites/libguides/libguides.css ./dist/libguides.css 
 cp ./sites/libguides/restyle.css ./dist/libguides_restyle.css 
 
-# copy browser_compatibility.js into ./dist
-cp ./src/_helpers/browser_compatibility.js ./dist/
-
 # move icons into dist/
 mkdir ./dist/icons || true;
 cp ./assets/icons/* ./dist/icons/

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 rm -rf dist/ || true; 
-rm -rf node_modules/ || true;
+# rm -rf node_modules/ || true;
 rm -rf _site/ || true;
 rm -rf .sass-cache/ || true 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,8 +3,8 @@
 # exit when any command fails
 set -e
 
-# update the NPM package
-npm run build:all 
+# rebuild, update, and publish as package
+npm run build:all
 npm version patch
 npm publish
 

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -3,8 +3,13 @@
 # exit when any command fails
 set -e; 
 
-npm run reinstall;
-npm run css
+# run each build step/version from scratch
+npm run clean;
+npm run css;
 npm run build:rollup;
 # npm run build:owc;
 npm run build:storybook;
+
+# copy over select files into the 'dist/' folder
+cp src/_helpers/browser_compatibility.js ./dist/;
+cp sites/*/*.js ./dist/;

--- a/sites/wordpress/search_redirector_override.js
+++ b/sites/wordpress/search_redirector_override.js
@@ -1,0 +1,27 @@
+/**
+ * NOTE: this is a bit of a quick-fix solution to resolve a production issue WEB-194.
+ * 
+ * - the following hijacks the search form submission on the home page, preventing 
+ *   a call from being made to https://github.com/bu-ist/bu-library-theme/blob/master/search-redirector.php,
+ *   which, if allowed, results in 403 errors due to 'Web Application Firewall' configurations by IS&T
+ * - it
+ */
+
+let doBULSCatalogSearch = function(query){
+  let base_url = "https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?tab=default_tab&search_scope=default_scope&vid=BU&lang=en_US&query=";
+  window.location = base_url+encodeURIComponent(query);
+}
+
+if(window.location.pathname === "/library/"){ 
+  var bulibHomeSearchForm = document.querySelector("div#search > form");
+  var searchQueryInputElem = document.querySelector("div#search > form input#q");
+  var bulsOptionInputElem = document.querySelector("div#search > form input#search-catalog");
+
+  form.addEventListener('submit', (ev) => {
+    let qValue = searchQueryInputElem.value;
+    if(bulsOptionInputElem.hasAttribute("checked")){
+      doBULSCatalogSearch(qValue);
+      ev.preventDefault();
+    }
+  });
+};

--- a/sites/wordpress/search_redirector_override.js
+++ b/sites/wordpress/search_redirector_override.js
@@ -1,10 +1,13 @@
 /**
  * NOTE: this is a bit of a quick-fix solution to resolve a production issue WEB-194.
  * 
- * - the following hijacks the search form submission on the home page, preventing 
- *   a call from being made to https://github.com/bu-ist/bu-library-theme/blob/master/search-redirector.php,
- *   which, if allowed, results in 403 errors due to 'Web Application Firewall' configurations by IS&T
- * - it
+ *  - the following hijacks the search form submission on the home page, preventing 
+ *    a call from being made to https://github.com/bu-ist/bu-library-theme/blob/master/search-redirector.php
+ *    which, if allowed, results in 403 errors.
+ *  - we know from a previous issue (WEB-83) that this is likely due to the 'Web Application Firewall' 
+ *    configurations by IS&T, but redressing the issue has not been quick, and we don't want/need the redirector
+ *    going forward really, anyway 
+ *  - this patche should be replaced once the homepage is replaced by the '<bulib-search>' component.
  */
 
 let doBULSCatalogSearch = function(query){

--- a/sites/wordpress/search_redirector_override.js
+++ b/sites/wordpress/search_redirector_override.js
@@ -8,16 +8,16 @@
  */
 
 let doBULSCatalogSearch = function(query){
-  let base_url = "https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?tab=default_tab&search_scope=default_scope&vid=BU&lang=en_US&query=";
+  let base_url = "https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?tab=default_tab&search_scope=default_scope&vid=BU&lang=en_US&query=any,contains,";
   window.location = base_url+encodeURIComponent(query);
 }
 
 if(window.location.pathname === "/library/"){ 
-  var bulibHomeSearchForm = document.querySelector("div#search > form");
-  var searchQueryInputElem = document.querySelector("div#search > form input#q");
-  var bulsOptionInputElem = document.querySelector("div#search > form input#search-catalog");
+  let bulibHomeSearchForm = document.querySelector("div#search > form");
+  let searchQueryInputElem = document.querySelector("div#search > form input#q");
+  let bulsOptionInputElem = document.querySelector("div#search > form input#search-catalog");
 
-  form.addEventListener('submit', (ev) => {
+  bulibHomeSearchForm.addEventListener('submit', (ev) => {
     let qValue = searchQueryInputElem.value;
     if(bulsOptionInputElem.hasAttribute("checked")){
       doBULSCatalogSearch(qValue);


### PR DESCRIPTION
Related:
- Jira Tickets: [WEB-194](https://bulibrary.atlassian.net/browse/WEB-194), [WEB-83](https://bulibrary.atlassian.net/browse/WEB-83)
- Incident Reports: [INC12620667](https://bu.service-now.com/sp/?sys_id=815948a01bbf6b04fd8bb9dcdd4bcb59&view=sp&id=form&table=incident), [INC12762315](https://bu.service-now.com/sp?id=form&table=incident&view=sp&sys_id=acd7e5fd1b3b3b00fd8bb9dcdd4bcbbf) 

### Background
- our legacy search form on bu.edu/library is currently configured to call [`search_redirector.php`](https://github.com/bu-ist/bu-library-theme/blob/master/search-redirector.php) with a POST message
- in order to protect the form and the server from injection, IS&T has 'Web Application Firewall' rules that have caused `403` errors to happen with particular searches 
- primo searches can be constructed at the URL level, so there's no use for using that script and it can be circumvented entirely

### Description of Changes
- hijack call to search-redirector.php by conditionally preventing the default and resetting the `window.location`