### PR TITLE
WEB-224: Add 'Colors' demonstration to 'branding' section of storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,60 +4,92 @@ collection of web components and customizations used at Boston University Librar
 
 ### Description
 
-This repository contains web assets of Boston University Libraries that are used across a variety of our sites. 
-  These reusable pieces can be split into categories visible on the storybook [demo page](https://bulib.github.io/bulib-wc/):
-  - `lit-element`-based **[Web Components](https://github.com/bulib/bulib-wc/wiki/Web-Components)**, 
-  - sample html+css snippets usable without javascript ([**nojs**](https://github.com/bulib/bulib-wc/wiki/No-Javascript)) enabled, 
-  - and other **composites** of the two  
+This repository contains web assets of Boston University Libraries that are used across a variety of our sites and 
+  demonstrated in isolation via [storybook](https://bulib.github.io/bulib-wc/).
 
+These take a number of forms...
 
-### Usage/Workflow 
+- **site-specific code** (css, html, js) contained in `sites/`
+- **cross-platform styles**, theming, and icons managed in `assets/`
+- **reusable UI elements** (essentially custom widgets) in `src/`
+- and some pure **vanilla javascript helpers** (`src/_helpers/`)
+
+...and depend on a number of technologies...
+
+- vanilla **html+css** for interoperable, failsafe, cross-platform functionality [without javascript](https://github.com/bulib/bulib-wc/wiki/No-Javascript)
+- **[CSS Variables](https://github.com/bulib/bulib-wc/wiki/CSS-Variables)** for coordinating theming/branding
+  (especially [colors](https://bulib.github.io/bulib-wc/?path=/story/branding--colors))
+- **[Web Components](https://github.com/bulib/bulib-wc/wiki/Web-Components)** based on the `lit-element` library for more advanced functionality
+
+...towards the end of...
+
+- making the UI/UX/branding more consistent between platforms
+- enriching and increasing the interactivity of our sites
+- obtaining a greater degree of control and autonomy over our online presence from the vendors
+
+### Usage/Workflow
 
 #### Setup
+
 Install dependencies via node package manager
- ```
- $ git clone https://github.com/bulib/bulib-wc.git
- $ cd bulib-wc
- $ npm install
- ```
+
+```bash
+$ brew install node
+$ git clone https://github.com/bulib/bulib-wc.git
+$ cd bulib-wc
+$ npm install
+```
+
+_note: additional steps and troublshooting can be found in [the wiki](https://github.com/bulib/bulib-wc/wiki/Troubleshooting-Setup)_
 
 #### Running Locally
+
 running the following will open up a new tab in your browser at [`localhost:9001/?path=/story/`](http://localhost:9001/?path=/story/composites--ensemble), and watch for changes.
- ```
- $ npm run start
- ```
- you can make changes to _existing_ elements and see them in that running server by navigating to that component in the sidebar.
- to create a _new_ one, make a new entry in `/docs/index.stories.js` based off of the existing ones. 
- 
- 
+
+```bash
+$ npm run start
+```
+
+you can make changes to _existing_ elements and see them in that running server by navigating to that component in the sidebar.
+to create a _new_ one, make a new entry in `/docs/index.stories.js` based off of the existing ones
+
 #### Building
+
 to build a bundle, run the following, noting that the default will use the `rollup.config.js`.
- ```
- $ npm run build 
- ```
- 
+
+```bash
+$ npm run build
+```
+
 or a bundle with `open-wc` version (with codesplitting), run:
- ```
- $ npm run build:owc 
- ```
- 
+
+```bash
+$ npm run build:owc
+```
+
 you can also build a static copy of the static docs site via:
- ``` 
- $ npm run build:storybook 
- ```
- 
+
+```bash
+$ npm run build:storybook
+```
+
 #### Deploying
-We expect to continue to manage versioning this repository with npm. 
- ```
- $ npm publish
- ```
- 
+
+We expect to continue to manage versioning this repository with npm.
+
+```bash
+$ npm publish
+```
+
 that said, we want to make sure that our docs page is updated, so it's recommended to use the following, instead:
- ```
- $ npm run publish
- ```
- 
-if you want to update the docs page before you're finished developing, you can also update the docs directly via
- ```
- npm run deploy:storybook
- ```
+
+```bash
+$ npm run deploy
+```
+
+if you want to update the docs page before you're finished developing (without publishing the package), you can also update the _docs directly_ via
+
+```bash
+$ npm run deploy:storybook
+```
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ collection of web components and customizations used at Boston University Librar
 
 ### Description
 
-This repository contains web assets of Boston University Libraries that are used across a variety of our sites and 
+This repository contains web assets of Boston University Libraries that are used across a variety of our sites and
   demonstrated in isolation via [storybook](https://bulib.github.io/bulib-wc/).
 
 These take a number of forms...

--- a/README.md
+++ b/README.md
@@ -93,3 +93,28 @@ if you want to update the docs page before you're finished developing (without p
 $ npm run deploy:storybook
 ```
 
+#### Consuming
+
+We consume the published package over two main CDNs ([unkpg](https://unpkg.com), [jsdelivr](https://www.jsdelivr.com/)),
+  versioned and deployed using npm and added to each platform via a series of `<script>` and `<link>` tags stored in the `<head>`.
+
+All the **web components** are imported together from a single `index.js` file. Unpkg does some mapping here to chain together a
+  number of calls that leverage the `module` specification. This does the work that a bundler would do, but without the
+  extra build step, transpilation, etc.
+
+_note: one can import a specific version (e.g. `bulib-wc@0.0.92`) or the most recently published one (`bulib@latest`)_
+
+```html
+<!-- load web components -->
+<script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-loader.min.js"></script>
+<script src="https://unpkg.com/bulib-wc@0.1.0/src/index.js?module" type="module"></script>
+```
+
+For the **css**, we have both a shared bundle (created via `scripts/bundle_css.sh`), and site-specific forms for each `site_name`. 
+  These are imported via `<link>` like the following:
+
+```html
+<!-- styling -->
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bulib-wc@0.1.0/dist/bundle.min.css">
+<!--link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bulib-wc@latest/dist/{site_name}.css"-->
+```

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -71,6 +71,16 @@ body {
 
 /* - general styling - */
 
+/* make divs display in a series of tiles */
+div.tiles {
+  display:flex;
+  grid-gap: 10px;
+  flex-wrap: wrap;
+}
+div.tiles > * {
+  margin: 5px;
+}
+
 /* text */
 .txtl { text-align: left; }
 .txtc { text-align: center; }

--- a/docs/demo_brand.js
+++ b/docs/demo_brand.js
@@ -119,3 +119,64 @@ export const header_demo = `
       addSendGAEventOnAnchorClickToAnchorElements(ctaLinks, "cta");
     };
   </script>`;
+
+export const css_vars_demo = `
+  <h3>Primary</h3>
+  <p>Colors of the header and footer wrappers</p>
+
+  <div class="tiles">
+    <bulib-color var="--color-primary-background" white></bulib-color>
+    <bulib-color var="--color-primary-background-light" white></bulib-color>
+    <bulib-color var="--color-primary-background-dark" white></bulib-color>
+    <bulib-color var="--color-primary-text"></bulib-color>
+    <bulib-color var="--color-primary-text-light"></bulib-color>
+  </div>
+
+  <br /><hr />
+
+  <h3>Secondary</h3>
+  <p>Used in the banner (under the header)</p>
+
+  <div class="tiles">
+    <bulib-color var="--color-secondary-background"></bulib-color>
+    <bulib-color var="--color-secondary-background-dark"></bulib-color>
+    <bulib-color var="--color-secondary-text" white></bulib-color>
+    <bulib-color var="--color-secondary-text-dark" white></bulib-color>
+  </div>
+
+  <br /><hr />
+
+  <h3>Accent Color</h3>
+  <p>BU Official Red</p>
+
+  <div class="tiles">
+    <bulib-color var="--color-accent-background" white></bulib-color>
+    <bulib-color var="--color-accent-text"></bulib-color>
+    <bulib-color var="--color-accent-text-hover"></bulib-color>
+  </div>
+
+  <br /><hr />
+
+  <h3>Calls-to-Action</h3>
+  <p>Buttons and things to click on</p>
+
+  <div class="tiles">
+    <bulib-color var="--color-button-background" white></bulib-color>
+    <bulib-color var="--color-button-background-accent" white></bulib-color>
+    <bulib-color var="--color-button-background-dark" white></bulib-color>
+    <bulib-color var="--color-button-text"></bulib-color>
+  </div>
+
+  <br /><hr />
+`;
+
+export const footer_demo = `
+  <bulib-footer debug></bulib-footer>
+      
+  <br /><hr /><br />
+
+  <bulib-select 
+    sel_title="Select Simulated URL" opt_code="sample_urls" 
+    tag_name="bulib-footer" attr_name="curr_url"
+  ></bulib-select>
+`;

--- a/docs/demo_wc.js
+++ b/docs/demo_wc.js
@@ -81,3 +81,17 @@ export const wc_card_demo = (small) => `
 export const feedback_demo = `
   <bulib-feedback code="bulibwc-demo" debug prevent_action></bulib-feedback>
 `;
+
+export const color_demo = `
+  <h2><code>bulib-card</code></h2>
+
+  <h3><code>&lt;bulib-hours var="--color-primary-background"&gt;</code></h3>
+  <bulib-color var="--color-secondary-background-dark"></bulib-color>
+
+  <br /><hr />
+
+  <h3><code>&lt;bulib-hours val="red"&gt;</code></h3>
+  <bulib-color val="red" white></bulib-color>
+
+  <br /><hr />
+`;

--- a/docs/demo_wc.js
+++ b/docs/demo_wc.js
@@ -53,19 +53,6 @@ export const locoso_demo = `
   </bulib-select>
 `;
 
-export const header_demo = `<bulib-header></bulib-header>`;
-
-export const footer_demo = `
-  <bulib-footer debug></bulib-footer>
-      
-  <br /><hr /><br />
-
-  <bulib-select 
-    sel_title="Select Simulated URL" opt_code="sample_urls" 
-    tag_name="bulib-footer" attr_name="curr_url"
-  ></bulib-select>
-`;
-
 export const wc_card_demo = (small) => `
   <h2><code>bulib-card${small? " .small" : ""}</code></h2>
   <div class="deck">

--- a/docs/demo_wc.js
+++ b/docs/demo_wc.js
@@ -70,14 +70,14 @@ export const feedback_demo = `
 `;
 
 export const color_demo = `
-  <h2><code>bulib-card</code></h2>
+  <h2><code>bulib-color</code></h2>
 
-  <h3><code>&lt;bulib-hours var="--color-primary-background"&gt;</code></h3>
+  <h3><code>&lt;bulib-color var="--color-primary-background"&gt;</code></h3>
   <bulib-color var="--color-secondary-background-dark"></bulib-color>
 
   <br /><hr />
 
-  <h3><code>&lt;bulib-hours val="red"&gt;</code></h3>
+  <h3><code>&lt;bulib-color val="red"&gt;</code></h3>
   <bulib-color val="red" white></bulib-color>
 
   <br /><hr />

--- a/docs/index.stories.js
+++ b/docs/index.stories.js
@@ -3,23 +3,24 @@ import { storiesOf, withKnobs } from '@open-wc/demoing-storybook';
 
 // demos
 import {header_demo, ensemble_demo} from './demo_comp';
-import {search_demo, hours_demo, locoso_demo, footer_demo, feedback_demo, wc_card_demo} from './demo_wc';
+import {color_demo, feedback_demo, hours_demo, locoso_demo, search_demo, footer_demo, wc_card_demo} from './demo_wc';
 import {card_demo, cta_demo} from './demo_nojs';
 
 // css
 import '../assets/css/shared.css';
 
-storiesOf('composites', module)
+storiesOf('branding', module)
   .addDecorator(withKnobs)
-  .add('ensemble',     () => header_demo + ensemble_demo)
+  .add('kitchen sink', () => header_demo + ensemble_demo)
   .add('bulib-header', () => header_demo)
   .add('bulib-footer', () => footer_demo)
 ;
-
+  
 storiesOf('components', module)
   .addDecorator(withKnobs)
 //.add('bulib-search', () => withClassPropertiesKnobs(BULibSearch))
   .add('bulib-card',    () => wc_card_demo(false)+wc_card_demo(true))
+  .add('bulib-color',   () => color_demo)
   .add('bulib-feedback',() => feedback_demo)
   .add('bulib-hours',   () => hours_demo)
   .add('bulib-locoso',  () => locoso_demo)

--- a/docs/index.stories.js
+++ b/docs/index.stories.js
@@ -2,8 +2,8 @@ import '../src/index';
 import { storiesOf, withKnobs } from '@open-wc/demoing-storybook';
 
 // demos
-import {header_demo, ensemble_demo} from './demo_comp';
-import {color_demo, feedback_demo, hours_demo, locoso_demo, search_demo, footer_demo, wc_card_demo} from './demo_wc';
+import {header_demo, ensemble_demo, css_vars_demo, footer_demo,} from './demo_brand';
+import {color_demo, feedback_demo, hours_demo, locoso_demo, search_demo, wc_card_demo} from './demo_wc';
 import {card_demo, cta_demo} from './demo_nojs';
 
 // css
@@ -12,6 +12,7 @@ import '../assets/css/shared.css';
 storiesOf('branding', module)
   .addDecorator(withKnobs)
   .add('kitchen sink', () => header_demo + ensemble_demo)
+  .add('colors',       () => css_vars_demo)
   .add('bulib-header', () => header_demo)
   .add('bulib-footer', () => footer_demo)
 ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "css": "./scripts/bundle_css.sh",
     "prestart": "npm run css",
     "start": "npm install && start-storybook -p 9001",
+    "build": "npm run build:rollup",
     "build:all": "./scripts/rebuild.sh",
     "build:rollup": "rollup -c rollup.config.js",
     "build:owc": "rollup -c rollup.config.owc.js",

--- a/src/color/bulib-color.js
+++ b/src/color/bulib-color.js
@@ -1,0 +1,3 @@
+import BULibColor from './color';
+
+window.customElements.define("bulib-color", BULibColor);

--- a/src/color/color.js
+++ b/src/color/color.js
@@ -1,0 +1,39 @@
+import {LitElement, html, css} from 'lit-element/lit-element';
+
+/** context-sensitive search form allowing you to search across multiple 'search_options' */
+export default class BULibColor extends LitElement {
+
+  static get properties() {
+    return {
+      var: {type: String}, /** name of a css variable */
+      val: {type: String}, /** color code */
+      white: {type: Boolean}
+    }
+  }
+
+  static get styles(){
+    return [
+      css`
+        div.color-box { background-color: #eee; }
+        .color-box > div { 
+          padding: 10px; 
+          border: solid black 1px;
+          font-weight: bold;
+        }
+      `
+    ]
+  }
+
+  render() {
+    let name = !!this.var? this.var : this.val || "[unknown]";
+    let computed = getComputedStyle(document.body).getPropertyValue(this.var) || this.val;
+
+    return html`
+      <div class="color-box" style="width: fit-content; min-width: 75px; text-align: left;">
+        <div><strong>${name}</strong></div>
+        <div style="background-color: ${computed}; color: ${this.white? 'white' : 'black'}">${computed}</div>
+      </div>
+    `;
+  }
+}
+window.customElements.define("bulib-color", BULibColor);

--- a/src/color/color.js
+++ b/src/color/color.js
@@ -36,4 +36,3 @@ export default class BULibColor extends LitElement {
     `;
   }
 }
-window.customElements.define("bulib-color", BULibColor);

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -118,6 +118,7 @@ export default class BULibFooter extends LitElement {
         .ftr-right  { grid-area: ftr-rt; border-bottom: solid lightgrey 1px; }
 
         /* '*Boston University* Libraries' styling */
+        .bulib-typeface h3 a > span { font-weight: 400; }
         .bulib-typeface a { 
           text-decoration: none !important; 
           font-size: large; 
@@ -197,7 +198,7 @@ export default class BULibFooter extends LitElement {
             <div class="txtc">
               <div class="bulib-typeface">
                 <h3>
-                  <a class="white-link" @click="${(ev) => {sendGAEventFromClickEvent(ev, 'bulib-footer');}}" href="https://www.bu.edu/library">
+                  <a @click="${(ev) => {sendGAEventFromClickEvent(ev, 'bulib-footer');}}" href="https://www.bu.edu/library">
                     <strong>Boston University</strong>&nbsp; <span>Libraries</span>
                   </a>
                 </h3>

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -195,7 +195,7 @@ div.dropdown.menu-item {
     margin-bottom: 20px;
     padding-right: 10px; }
     .banner h1 a, .banner span a {
-      color: var(--color-secondary-text-link, black);
+      color: var(--color-secondary-text-dark, black);
       text-decoration: none;
       cursor: pointer; }
     .banner h1 a:last-child, .banner span a:last-child {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ WebComponents.waitFor(function(){
   import ('./card/bulib-card');
   import ('./libhours/bulib-hours');
   import ('./search/bulib-search');
+  import ('./color/bulib-color');
   import ('./locoso/bulib-locoso');
   import ('./footer/bulib-footer');
 });


### PR DESCRIPTION
### Description of Changes
- update the 'ensemble' section to 'branding'
- add 'colors' entry to 'branding' section
- create a new 'bulib-color' 

### Screenshots
![overall demonstration](https://user-images.githubusercontent.com/5565284/68164625-5702f900-ff2b-11e9-9d84-811f0ea8d245.png)

![display a single color](https://user-images.githubusercontent.com/5565284/68164861-f1633c80-ff2b-11e9-9d87-03576a55699b.png)

