### PR TITLE
WEB-264-267-276: Minor updates to 'homepage-link' tracking, library/library links, and library/about/hours styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/sites/wordpress/hompeage-link.html
+++ b/sites/wordpress/hompeage-link.html
@@ -1,0 +1,43 @@
+<script id="homepage-link-tracking" type="module">
+  import {addSendGAEventOnAnchorClickToAnchorElements} from "https://unpkg.com/bulib-wc@0.1.4/src/_helpers/google_analytix.js?module";
+
+
+  window.onload = function(){
+
+    // search box
+    let searchBoxLinks = document.querySelectorAll("#search > p.advanced a");
+    addSendGAEventOnAnchorClickToAnchorElements(searchBoxLinks, "homepage-link", "search-box");
+
+    // research
+    let researchTopics = document.querySelectorAll("#menu-home-links-research-expanded a");
+    let researchLocations = document.querySelectorAll("#research-locations-list a");
+    let researchGuides = document.querySelectorAll("#menu-home-links-research > #menu-item-37934 a");
+    let researchCollections = document.querySelectorAll("#menu-home-links-research > #menu-item-31309 a");
+    addSendGAEventOnAnchorClickToAnchorElements(researchTopics, "homepage-link", "research-topics");
+    addSendGAEventOnAnchorClickToAnchorElements(researchLocations, "homepage-link", "research-locations");
+    addSendGAEventOnAnchorClickToAnchorElements(researchGuides, "homepage-link", "research-guides");
+    addSendGAEventOnAnchorClickToAnchorElements(researchCollections, "homepage-link", "research-collections");
+
+    // services
+    let servicesTopics = document.querySelectorAll("#menu-home-links-services-expanded a");
+    let servicesLocations = document.querySelectorAll("#services-locations-list a");
+    let servicesBorrowing = document.querySelectorAll("#menu-home-links-services > #menu-item-37937 a");
+    let servicesHelp = document.querySelectorAll("#menu-home-links-services > #menu-item-35887 a");
+    addSendGAEventOnAnchorClickToAnchorElements(servicesTopics, "homepage-link", "services-topics");
+    addSendGAEventOnAnchorClickToAnchorElements(servicesLocations, "homepage-link", "services-locations");
+    addSendGAEventOnAnchorClickToAnchorElements(servicesBorrowing, "homepage-link", "services-borrowing");
+    addSendGAEventOnAnchorClickToAnchorElements(servicesHelp, "homepage-link", "services-help");
+
+    // about
+    let aboutTopics = document.querySelectorAll("#menu-home-links-about-expanded a");
+    let aboutLocations = document.querySelectorAll("#about-locations-list a");
+    let aboutHours = document.querySelectorAll("#home-links-about > #menu-item-22914 a");
+    let aboutWhoWhere = document.querySelectorAll("#home-links-about > #menu-item-35895 a");
+    let aboutNews = document.querySelectorAll("#home-links-about > #menu-item-30557 a");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutTopics, "homepage-link", "about-topics");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutLocations, "homepage-link", "about-locations");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutHours, "homepage-link", "research-guides");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutWhoWhere, "homepage-link", "about-who");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutNews, "homepage-link", "about-news");
+  }
+</script>

--- a/sites/wordpress/hompeage-link.html
+++ b/sites/wordpress/hompeage-link.html
@@ -13,8 +13,8 @@
     let researchLocations = document.querySelectorAll("#research-locations-list a");
     let researchGuides = document.querySelectorAll("#menu-home-links-research > #menu-item-37934 a");
     let researchCollections = document.querySelectorAll("#menu-home-links-research > #menu-item-31309 a");
-    addSendGAEventOnAnchorClickToAnchorElements(researchTopics, "homepage-link", "research-topics");
-    addSendGAEventOnAnchorClickToAnchorElements(researchLocations, "homepage-link", "research-locations");
+    addSendGAEventOnAnchorClickToAnchorElements(researchTopics, "homepage-link", "research-dropdown-topics");
+    addSendGAEventOnAnchorClickToAnchorElements(researchLocations, "homepage-link", "research-dropdown-locations");
     addSendGAEventOnAnchorClickToAnchorElements(researchGuides, "homepage-link", "research-guides");
     addSendGAEventOnAnchorClickToAnchorElements(researchCollections, "homepage-link", "research-collections");
 
@@ -23,8 +23,8 @@
     let servicesLocations = document.querySelectorAll("#services-locations-list a");
     let servicesBorrowing = document.querySelectorAll("#menu-home-links-services > #menu-item-37937 a");
     let servicesHelp = document.querySelectorAll("#menu-home-links-services > #menu-item-35887 a");
-    addSendGAEventOnAnchorClickToAnchorElements(servicesTopics, "homepage-link", "services-topics");
-    addSendGAEventOnAnchorClickToAnchorElements(servicesLocations, "homepage-link", "services-locations");
+    addSendGAEventOnAnchorClickToAnchorElements(servicesTopics, "homepage-link", "services-dropdown-topics");
+    addSendGAEventOnAnchorClickToAnchorElements(servicesLocations, "homepage-link", "services-dropdown-locations");
     addSendGAEventOnAnchorClickToAnchorElements(servicesBorrowing, "homepage-link", "services-borrowing");
     addSendGAEventOnAnchorClickToAnchorElements(servicesHelp, "homepage-link", "services-help");
 
@@ -34,8 +34,8 @@
     let aboutHours = document.querySelectorAll("#home-links-about > #menu-item-22914 a");
     let aboutWhoWhere = document.querySelectorAll("#home-links-about > #menu-item-35895 a");
     let aboutNews = document.querySelectorAll("#home-links-about > #menu-item-30557 a");
-    addSendGAEventOnAnchorClickToAnchorElements(aboutTopics, "homepage-link", "about-topics");
-    addSendGAEventOnAnchorClickToAnchorElements(aboutLocations, "homepage-link", "about-locations");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutTopics, "homepage-link", "about-dropdown-topics");
+    addSendGAEventOnAnchorClickToAnchorElements(aboutLocations, "homepage-link", "about-dropdown-locations");
     addSendGAEventOnAnchorClickToAnchorElements(aboutHours, "homepage-link", "research-guides");
     addSendGAEventOnAnchorClickToAnchorElements(aboutWhoWhere, "homepage-link", "about-who");
     addSendGAEventOnAnchorClickToAnchorElements(aboutNews, "homepage-link", "about-news");

--- a/sites/wordpress/wordpress.css
+++ b/sites/wordpress/wordpress.css
@@ -21,6 +21,12 @@ li.style-scope.bulib-footer {
 #hours-display { font-size: 100% !important; }
 
 
+/* - library & service hours (/library/about/hours/) - */
+.s-lc-whw-bh > button {
+  padding: 5px;
+  font-size: large;
+}
+
 /* - floorplans - */
 
 /* locate by floor styling */

--- a/src/_helpers/google_analytix.js
+++ b/src/_helpers/google_analytix.js
@@ -12,9 +12,7 @@ export function sendGAEvent(eventName, action, label, value){
   try{
     if(window.gtag && !PREVENT_GA_CALL){ 
       window.gtag('event', action, {
-        'event_category': eventName,
-        'event_label': label,
-        'value': value
+        'event_category': eventName, 'event_label': label, 'value': value
       });
       logGoogleAnalyticsMessage("window.gtag() found and called");
     }else if(window.ga && !PREVENT_GA_CALL){ 
@@ -47,14 +45,17 @@ export function sendGAEventFromClickEvent(clickEvent, eventName, actionName){
   }
 
   // allow user to specify an actionName as well as the eventName, pushing contentClicked into the label
-  if(typeof(actionName == "undefined")){
+  if(!actionName || actionName == ""){
+    logGoogleAnalyticsMessage(`actionName considered 'undefined' or empty. sending action:'${contentClicked}', label:'${window.location.pathname}'.`)
     sendGAEvent(eventName, contentClicked, window.location.pathname);
   }else{
+    logGoogleAnalyticsMessage(`actionName '${actionName}' registered as a real value, sending action with label as contentClicked: '${contentClicked}'`)
     sendGAEvent(eventName, actionName, contentClicked);
   }
 }
 
 export function addSendGAEventOnAnchorClickToAnchorElements(anchorElements, eventName, actionName){
+  logGoogleAnalyticsMessage(`anchorElements: '${anchorElements}', eventName: '${eventName}', actionName: '${actionName}'`);
   for(let i=0; i<anchorElements.length; i++){
     anchorElements[i].addEventListener("click", (ev) => sendGAEventFromClickEvent(ev, eventName, actionName));
   }

--- a/src/_helpers/google_analytix.js
+++ b/src/_helpers/google_analytix.js
@@ -29,25 +29,33 @@ export function sendGAEvent(eventName, action, label, value){
   }
 }
 
-export function sendGAEventFromClickEvent(clickEvent, eventName){
+export function sendGAEventFromClickEvent(clickEvent, eventName, actionName){
   let contentClicked = "[unknown]"; 
   
+  // obtain a label for the clicked link from its markup
   try{ 
     contentClicked = clickEvent.target.innerText 
       ? clickEvent.target.innerText 
       : clickEvent.target.querySelector("span").innerText 
       || "[unknown]";
     contentClicked = contentClicked.replace(/\//,"").replace(/\&/,"");  // remove special characters
+    contentClicked = contentClicked.substring(0, contentClicked.indexOf(" (")); // remove any parentheses from the slug
     contentClicked = contentClicked.toLowerCase().replace(/ +/g,"-");   // slugify (lowercase, dashes)
   }catch(err){
     logGoogleAnalyticsMessage("error getting contentClicked from clickEvent: ");
     if(DEBUG_ANALYTICS){ console.log(err); }
   }
-  sendGAEvent(eventName, contentClicked, window.location.pathname);
+
+  // allow user to specify an actionName as well as the eventName, pushing contentClicked into the label
+  if(typeof(actionName == "undefined")){
+    sendGAEvent(eventName, contentClicked, window.location.pathname);
+  }else{
+    sendGAEvent(eventName, actionName, contentClicked);
+  }
 }
 
-export function addSendGAEventOnAnchorClickToAnchorElements(anchorElements, eventName){
+export function addSendGAEventOnAnchorClickToAnchorElements(anchorElements, eventName, actionName){
   for(let i=0; i<anchorElements.length; i++){
-    anchorElements[i].addEventListener("click", (ev) => sendGAEventFromClickEvent(ev, eventName));
+    anchorElements[i].addEventListener("click", (ev) => sendGAEventFromClickEvent(ev, eventName, actionName));
   }
 }

--- a/src/_helpers/google_analytix.js
+++ b/src/_helpers/google_analytix.js
@@ -1,4 +1,4 @@
-const DEBUG_ANALYTICS = true;
+const DEBUG_ANALYTICS = false;
 const PREVENT_GA_CALL = false;
 
 function logGoogleAnalyticsMessage(message){
@@ -54,7 +54,7 @@ export function sendGAEventFromClickEvent(clickEvent, eventName, actionName){
 }
 
 export function addSendGAEventOnAnchorClickToAnchorElements(anchorElements, eventName, actionName){
-  logGoogleAnalyticsMessage(`anchorElements: '${anchorElements}', eventName: '${eventName}', actionName: '${actionName}'`);
+  logGoogleAnalyticsMessage(`adding click listeners with eventName:'${eventName}', actionName:'${actionName}'`);
   for(let i=0; i<anchorElements.length; i++){
     anchorElements[i].addEventListener("click", (ev) => sendGAEventFromClickEvent(ev, eventName, actionName));
   }

--- a/src/_helpers/google_analytix.js
+++ b/src/_helpers/google_analytix.js
@@ -36,8 +36,7 @@ export function sendGAEventFromClickEvent(clickEvent, eventName, actionName){
       ? clickEvent.target.innerText 
       : clickEvent.target.querySelector("span").innerText 
       || "[unknown]";
-    contentClicked = contentClicked.replace(/\//,"").replace(/\&/,"");  // remove special characters
-    contentClicked = contentClicked.substring(0, contentClicked.indexOf(" (")); // remove any parentheses from the slug
+    contentClicked = contentClicked.replace(/[^a-zA-Z0-9 ]/g, '');  // remove special characters
     contentClicked = contentClicked.toLowerCase().replace(/ +/g,"-");   // slugify (lowercase, dashes)
   }catch(err){
     logGoogleAnalyticsMessage("error getting contentClicked from clickEvent: ");

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -8,12 +8,12 @@ const sitemap_values = {
     "wordpress":{
     "header":"About the Libraries",
     "links":[
-      {"title":"InterLibrary Borrowing","href":"https://www.bu.edu/library/library/services/ill/"},
-      {"title":"Course Reserves",       "href":"https://www.bu.edu/library/library/services/reserves/"},
-      {"title":"For Alumni",            "href":"https://www.bu.edu/library/library/services/alumni/"},
-      {"title":"Staff Directory",       "href":"https://www.bu.edu/library/library/about/who-we-are/staff-directory/"},
-      {"title":"Maps & Floorplans",     "href":"https://www.bu.edu/library/library/about/maps-floorplans/"},
-      {"title":"For Faculty",           "href":"https://www.bu.edu/library/library/services/for-faculty/"}
+      {"title":"InterLibrary Borrowing","href":"https://www.bu.edu/library/services/ill/"},
+      {"title":"Course Reserves",       "href":"https://www.bu.edu/library/services/reserves/"},
+      {"title":"For Alumni",            "href":"https://www.bu.edu/library/services/alumni/"},
+      {"title":"Staff Directory",       "href":"https://www.bu.edu/library/about/who-we-are/staff-directory/"},
+      {"title":"Maps & Floorplans",     "href":"https://www.bu.edu/library/about/maps-floorplans/"},
+      {"title":"For Faculty",           "href":"https://www.bu.edu/library/services/for-faculty/"}
     ]
   },"askalibrarian":{
     "header":"Ask A Librarian",


### PR DESCRIPTION
### [WEB-264](https://bulibrary.atlassian.net/browse/WEB-264) - `homepage-link` tracking

add google analytics tracking for `homepage-links`

![ga for hompage](https://user-images.githubusercontent.com/5565284/72284452-fec53300-360e-11ea-9b6c-a23e22c4c7f1.png)

### [WEB-276](https://bulibrary.atlassian.net/browse/WEB-276) - `/library/library` footer links

`library/library` error removed from the footer links

![footer links don't have extra 'library' anymore](https://user-images.githubusercontent.com/5565284/72284548-40ee7480-360f-11ea-8c75-ceaca3d3175c.png)

### [WEB-267](https://bulibrary.atlassian.net/browse/WEB-257): `library/about/hours` styling

assorted library hours styling changes 

![changes to the ](https://user-images.githubusercontent.com/5565284/72284570-54014480-360f-11ea-9d5b-8e6b4802b876.png)
