### PR TITLE
WEB-277: Colors - expand color palette with values from primo-explore-devenv-bu

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -8,7 +8,7 @@ body {
   --color-primary-text-light: white;
 
   /* BU official red accent background [http://www.bu.edu/brand/guidelines/design/colors/] */
-  --color-accent-background: #CC0000;
+  --color-accent-red-background: #CC0000;
   --color-accent-text: whitesmoke;
   --color-accent-text-hover: white;
 

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -2,21 +2,27 @@
 body {
   /* primary background (black) */
   --color-primary-background: #2D2926;
-  --color-primary-background-light: rgb(74, 71, 70);
+  --color-primary-background-light: #4a4746;
   --color-primary-background-dark: black;
   --color-primary-text: #e1e1e1;
   --color-primary-text-light: white;
 
   /* BU official red accent background [http://www.bu.edu/brand/guidelines/design/colors/] */
   --color-accent-red-background: #CC0000;
+  --color-accent-orange-background: #BB7933;
+  --color-accent-green-background: #147114;
+  --color-accent-blue-highlight: #DCF3FF;
+  --color-accent-blue-hover: rgba(51, 152, 187, 0.1); 
   --color-accent-text: whitesmoke;
   --color-accent-text-hover: white;
 
   /* button/call to action (blue) */
   --color-button-background: #257abe;
-  --color-button-background-accent: #06605A;
+  --color-button-background-light: #639CC9;
   --color-button-background-dark: #1B598C;
+  --color-button-background-accent: #06605A;
   --color-button-text: whitesmoke;
+  --color-button-text-light: white;
 
   /* secondary background color (very light grey) */
   --color-secondary-background: #eeeeee /*rgba(200,200,200,0.3)*/;

--- a/src/color/color.js
+++ b/src/color/color.js
@@ -14,7 +14,7 @@ export default class BULibColor extends LitElement {
       /** name of a known, default css variable (e.g. 'blue', 'red') */
       var: {type: String},
 
-      /** css variable set somewhere within the scope and visible via var() (e.g. '--color-accent-background' )*/
+      /** css variable set somewhere within the scope and visible via var() (e.g. '--color-accent-red-background' )*/
       val: {type: String}, /** color code */
 
       /** whether to have a white or a black background  */

--- a/src/color/color.stories.mdx
+++ b/src/color/color.stories.mdx
@@ -13,7 +13,7 @@ import './bulib-color.js';
 # Color Component
 
 (testing) Demonstrate a given color with a predetermined primitive _value_ (e.g. `val="red"`) 
-  or a css _variable_ (`var="--color-accent-background"`)
+  or a css _variable_ (`var="--color-accent-red-background"`)
 
 ## Usages 
 
@@ -29,7 +29,7 @@ import './bulib-color.js';
 
 <Preview withToolbar>
   <Story name="Variable">
-    {html`<bulib-color var="--color-accent-background" white></bulib-color>`}
+    {html`<bulib-color var="--color-accent-red-background" white></bulib-color>`}
   </Story>
 </Preview>
 

--- a/src/nojs/colors.stories.mdx
+++ b/src/nojs/colors.stories.mdx
@@ -35,7 +35,7 @@ Colors that wrap the main content of the page, used in the header and footer.
 </Story>
 
 
-## Secondory (banner styling)
+## Secondary (banner styling)
 
 Used in the banner (under the header) and in various assorted section of UI (e.g. `tabs`).
 
@@ -62,9 +62,11 @@ Buttons, links, and things that the user can/should interact with.
   {html`
     <div class="tiles">
       <bulib-color var="--color-button-background" white></bulib-color>
-      <bulib-color var="--color-button-background-accent" white></bulib-color>
+      <bulib-color var="--color-button-background-light" white></bulib-color>
       <bulib-color var="--color-button-background-dark" white></bulib-color>
+      <bulib-color var="--color-button-background-accent" white></bulib-color>
       <bulib-color var="--color-button-text"></bulib-color>
+      <bulib-color var="--color-button-text-light"></bulib-color>
     </div>
   `}
 </Story>
@@ -80,6 +82,10 @@ Particular items (or calls to action) that you want to draw particular attention
   {html`
     <div class="tiles">
       <bulib-color var="--color-accent-red-background" white></bulib-color>
+      <bulib-color var="--color-accent-orange-background" white></bulib-color>
+      <bulib-color var="--color-accent-green-background" white></bulib-color>
+      <bulib-color var="--color-accent-blue-highlight"></bulib-color>
+      <bulib-color var="--color-accent-blue-hover"></bulib-color>
       <bulib-color var="--color-accent-text"></bulib-color>
       <bulib-color var="--color-accent-text-hover"></bulib-color>
     </div>

--- a/src/nojs/colors.stories.mdx
+++ b/src/nojs/colors.stories.mdx
@@ -79,7 +79,7 @@ Particular items (or calls to action) that you want to draw particular attention
 <Story name="Accents">
   {html`
     <div class="tiles">
-      <bulib-color var="--color-accent-background" white></bulib-color>
+      <bulib-color var="--color-accent-red-background" white></bulib-color>
       <bulib-color var="--color-accent-text"></bulib-color>
       <bulib-color var="--color-accent-text-hover"></bulib-color>
     </div>


### PR DESCRIPTION
Jira Ticket: [WEB-277](https://bulibrary.atlassian.net/browse/WEB-277)

Pull Request: [`primo-explore-devenv-bu`/#30](https://github.com/bulib/primo-explore-devenv-bu/pull/30)

### Background
- in rationalizing some of the `BU.css`, we found a bunch of colors in the theme that we wanted to capture and potentially reuse
- this expands upon the branding effort 

### Screenshots
updated CTAs and Accents
![updated colors](https://user-images.githubusercontent.com/5565284/72465670-9a88a780-37a5-11ea-8023-9194b78543dc.png)
