### PR TITLE
WEB-289: Customize template and filter controls for the 'Databases A-Z list'

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -81,3 +81,10 @@ i.material-icons, i.material-icons-outlined { vertical-align: middle; }
   white-space: nowrap; /* added line */
   border: 0;
 }
+
+/* secondary menu styling to accentuate things to edit the current page */
+.secondary-menu {
+  background-color: var(--color-secondary-background-light, gainsboro);
+  border: 1px solid var(--color-secondary-background-dark, grey);
+  padding: 10px;
+}

--- a/assets/css/layouts.css
+++ b/assets/css/layouts.css
@@ -32,5 +32,4 @@ div.tiles > * {
 }
 
 /* - flexbox shortcut - */
-.flex  { display: flex; }
 .flexw { display: flex; flex-wrap: wrap; }

--- a/assets/css/layouts.css
+++ b/assets/css/layouts.css
@@ -30,3 +30,7 @@ div.tiles {
 div.tiles > * {
   margin: 5px;
 }
+
+/* - flexbox shortcut - */
+.flex  { display: flex; }
+.flexw { display: flex; flex-wrap: wrap; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.9",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.9",
+  "version": "0.1.12",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/sites/libcal.css
+++ b/sites/libcal.css
@@ -10,3 +10,7 @@
   position: relative;
   background-color: var(--color-secondary-background, #f5f5f5);
 }
+
+/* pre-existing styles to hide parts */
+#s-lc-rm-groupdd { display: none;}
+#s-lc-rm-capacity-cont { display: none;}

--- a/sites/libguides/azlist.html
+++ b/sites/libguides/azlist.html
@@ -93,7 +93,7 @@
     <div class="banner-wrapper">
       <div class="banner">
         <div>
-          <h1><a href="/az.php">A-Z Databases List</a>&nbsp;</h1>
+          <h1><a href="/az.php">A-Z Databases</a>&nbsp;</h1>
           <div id="s-lib-bc">{{breadcrumbs}}</div>
         </div>
         
@@ -113,26 +113,29 @@
       <section>
         <div id="s-lg-az-search-bar" class="row">
           <div id="az-search-col-1" class="col-md-12 center">
-            {{navbar}}
+            <div id="s-lg-az-search-reset" class="pad-top-med pad-bottom-med">
+              {{search_reset}}
+            </div>
           </div>
         </div>
       </section>
       <section>
         <div id="s-lg-az-cols" class="row">
-          <div id="col1" class="col-md-8 center">
-            <div id="s-lg-az-filters" class="pad-right-sm pad-bottom-med">
-              <section>
-                <div id="s-lg-az-filter-cols" class="row">
-                  <div id="col-subjects" class="col-md-4 center">
-                    {{subject_list}}
-                  </div>
-                  <div id="col-types" class="col-md-4 center">
-                    {{type_list}}
-                  </div>
-                  <div id="col-vendors" class="col-md-4 center">
-                    {{vendor_list}}
-                  </div>
+          <div id="col1" class="col-lg-8 center">
+            <div id="s-lg-az-filters" class="secondary-menu">
+              <strong>Filter Database List:</strong>
+              <section id="s-lg-az-filter-cols" class="row">
+                <div id="col-subjects" class="col-sm-3">{{subject_list}}</div>
+                <div class="col-sm-6">
+                  <form class="flexw" role="search" onsubmit="springSpace.publicObj.filterAzBySearch(2345); return false;">
+                    <div style="flex: 1;">
+                      <label class="control-label sr-only" for="s-lg-az-search">DATABASES</label>
+                      <input type="text" id="s-lg-az-search" placeholder="Filter results" class="form-control">
+                    </div>
+                    <button type="submit" class="btn btn-default">Go</button>
+                  </form>
                 </div>
+                <div id="col-types" class="col-sm-3">{{type_list}}</div>
               </section>
             </div>
             <div id="s-lg-az-index" class="pad-right-sm">
@@ -151,16 +154,13 @@
               <img src="https://s3.amazonaws.com/libapps/sites/2345/icons/10443/gavel.jpg" hspace="3"> = Law School only
               <p>&nbsp;</p>
             </div>
-            <div id="s-lg-az-search-reset" class="pad-top-med pad-bottom-med">
-              {{search_reset}}
-            </div>
             <div id="s-lg-az-content" class="pad-right-sm pad-top-med">
               <div class="bold s-lib-color-lt-grey pad-top-med text-center">
                 Loading...
               </div>
             </div>
           </div>
-          <div id="col2" class="col-md-4 center">
+          <div id="col2" class="col-lg-4 center">
             <h4>Introducing Policy Map</h4>
             <p>
               <a href="https://bu-policymap-com.ezproxy.bu.edu/maps">Policy Map</a> 

--- a/sites/libguides/azlist.html
+++ b/sites/libguides/azlist.html
@@ -6,19 +6,101 @@
 	<body class="s-lib-public-body">
     
     <!-- BEGIN: Page Header -->
-    <p>
-      {{skip_link}}
-      {{public_header}}
-    </p>
-    <!-- END: Page Header -->
-
-    <!-- BEGIN: Content Header -->
-    <div id="s-lib-public-header" class="s-lib-header container s-lib-side-borders">
-      <div id="s-lib-bc">{{breadcrumbs}}</div>
-      <h1 id="s-lib-public-header-title">{{page_title}}</h1>
-      <div id="s-lib-public-header-desc">{{page_description}}</div>
+    <span>{{skip_link}}</span>
+    <div class="header-wrapper">
+      <nav>
+        <div class="primary-navbar">
+          <div class="primary-nav-left">
+            <a title="BU Libraries Homepage" href="https://www.bu.edu/library">
+              <img id="bu-logo" src="https://cdn.jsdelivr.net/npm/bulib-wc@latest/dist/icons/bulib-logo.png">
+            </a>
+          </div>
+          <div class="primary-nav-main menu-items-wrapper">
+            <ul class="menu-items">
+              <li id="subsite-research"><a href="https://www.bu.edu/library/research">Research</a></li>
+              <li id="subsite-services"><a href="https://www.bu.edu/library/services">Services</a></li>
+              <li id="subsite-about"><a href="https://www.bu.edu/library/">About</a></li>
+              <!-- <li id="subsite-guides"><a href="https://library.bu.edu/guides">Guides</a></li> -->
+              <!-- <li id="subsite-help"><a href="https://askalibrarian.bu.edu/">Help</a></li> -->
+            </ul>
+          </div>
+          <div class="primary-nav-right">
+            <div class="mobile-navigation none" aria-hidden="true">
+              <div id="menuToggle">
+                <!-- invisible toggle with hamburger -->
+                <input type="checkbox" tabindex="-1"/>
+                <span></span>
+                <span></span>
+                <span></span>
+                
+                <!-- mobile nav menu -->
+                <ul id="mobile-menu">
+                  <li id="subsite-research"><a href="https://www.bu.edu/library/research">Research</a></li>
+                  <li id="subsite-services"><a href="https://www.bu.edu/library/services">Services</a></li>
+                  <li id="subsite-about"><a href="https://www.bu.edu/library/">About</a></li>
+                  <li><hr /></li>
+                  <li><a href="https://www.bu.edu/library/about">Library Locations</a></li>
+                  <li><a href="https://askalibrarian.bu.edu/">Ask a Librarian</a></li>
+                </ul>
+              </div>
+            </div>
+            <div class="top-right">
+              <ul class="menu-items">
+                <li>
+                  <div class="dropdown">
+                    <a class="menu-item inline" href="https://www.bu.edu/library/about">
+                      <span class="labeled-icon prs">Library Locations</span><i class="material-icons inline">arrow_drop_down</i>
+                    </a>
+                    <div class="dropdown-content">
+                      <ul class="library-list no-bullet">
+                        <li><a href="https://www.bu.edu/library/african-studies/">African Studies Library</a></li>
+                        <li><a href="https://www.bu.edu/library/astronomy/">Astronomy Library</a></li>
+                        <!-- <li><a href="https://www.bu.edu/disc/">Digital Collections</a></li> -->
+                        <li><a href="http://archives.bu.edu/">Howard Gotlieb Archival Research Center</a></li>
+                        <li><a href="https://www.bu.edu/library/mugar-memorial/">Mugar Memorial Library</a></li>
+                        <li><a href="https://www.bu.edu/library/music/">Music Library</a></li>
+                        <!-- <li><a href="https://open.bu.edu/">OpenBU</a></li> -->
+                        <li><a href="https://www.bu.edu/library/management/">Pardee Management Library</a></li>
+                        <li><a href="https://www.bu.edu/library/pickering-educational/">Pickering Educational Resources Library</a></li>
+                        <li><a href="https://www.bu.edu/library/sel/">Science &amp; Engineering Library</a></li>
+                        <li><a href="https://www.bu.edu/library/stone-science/">Stone Science Library</a></li>
+                        <li><a href="https://www.bu.edu/library/about/additional-libraries/">Additional Libraries</a></li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+                <li>
+                  <a class="menu-item inline" href="https://askalibrarian.bu.edu/">
+                    <span class="labeled-icon prl">Ask a Librarian</span><i class="material-icons inline">question_answer</i>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <script id="mobile-nav-clickout" type="text/javascript">
+          let input = document.querySelector("#menuToggle > input");
+          window.addEventListener("click", (event) => {
+            let clicked = event.target;
+            let clicked_within_mobile_menu = clicked.closest("#menuToggle") != null;
+            if(input && clicked != input && !clicked_within_mobile_menu || clicked.tagName == "A"){
+              input.checked = false; // uncheck the #menuToggle input, closing the mobile nav
+            }
+          });
+        </script>
+      </nav>
     </div>
-    <!-- END: Content Header -->
+    <div class="banner-wrapper">
+      <div class="banner">
+        <div>
+          <h1><a href="/az.php">A-Z Databases List</a>&nbsp;</h1>
+          <div id="s-lib-bc">{{breadcrumbs}}</div>
+        </div>
+        
+        <bulib-search str_options="db guides primo"></bulib-search>
+      </div>
+    </div>
+    <!-- END: Page Header -->
 
     <!-- BEGIN: Nav Bar -->
     <div id="s-lib-public-nav" class="container s-lib-side-borders">

--- a/sites/libguides/azlist.html
+++ b/sites/libguides/azlist.html
@@ -7,100 +7,16 @@
     
     <!-- BEGIN: Page Header -->
     <span>{{skip_link}}</span>
-    <div class="header-wrapper">
-      <nav>
-        <div class="primary-navbar">
-          <div class="primary-nav-left">
-            <a title="BU Libraries Homepage" href="https://www.bu.edu/library">
-              <img id="bu-logo" src="https://cdn.jsdelivr.net/npm/bulib-wc@latest/dist/icons/bulib-logo.png">
-            </a>
-          </div>
-          <div class="primary-nav-main menu-items-wrapper">
-            <ul class="menu-items">
-              <li id="subsite-research"><a href="https://www.bu.edu/library/research">Research</a></li>
-              <li id="subsite-services"><a href="https://www.bu.edu/library/services">Services</a></li>
-              <li id="subsite-about"><a href="https://www.bu.edu/library/">About</a></li>
-              <!-- <li id="subsite-guides"><a href="https://library.bu.edu/guides">Guides</a></li> -->
-              <!-- <li id="subsite-help"><a href="https://askalibrarian.bu.edu/">Help</a></li> -->
-            </ul>
-          </div>
-          <div class="primary-nav-right">
-            <div class="mobile-navigation none" aria-hidden="true">
-              <div id="menuToggle">
-                <!-- invisible toggle with hamburger -->
-                <input type="checkbox" tabindex="-1"/>
-                <span></span>
-                <span></span>
-                <span></span>
-                
-                <!-- mobile nav menu -->
-                <ul id="mobile-menu">
-                  <li id="subsite-research"><a href="https://www.bu.edu/library/research">Research</a></li>
-                  <li id="subsite-services"><a href="https://www.bu.edu/library/services">Services</a></li>
-                  <li id="subsite-about"><a href="https://www.bu.edu/library/">About</a></li>
-                  <li><hr /></li>
-                  <li><a href="https://www.bu.edu/library/about">Library Locations</a></li>
-                  <li><a href="https://askalibrarian.bu.edu/">Ask a Librarian</a></li>
-                </ul>
-              </div>
-            </div>
-            <div class="top-right">
-              <ul class="menu-items">
-                <li>
-                  <div class="dropdown">
-                    <a class="menu-item inline" href="https://www.bu.edu/library/about">
-                      <span class="labeled-icon prs">Library Locations</span><i class="material-icons inline">arrow_drop_down</i>
-                    </a>
-                    <div class="dropdown-content">
-                      <ul class="library-list no-bullet">
-                        <li><a href="https://www.bu.edu/library/african-studies/">African Studies Library</a></li>
-                        <li><a href="https://www.bu.edu/library/astronomy/">Astronomy Library</a></li>
-                        <!-- <li><a href="https://www.bu.edu/disc/">Digital Collections</a></li> -->
-                        <li><a href="http://archives.bu.edu/">Howard Gotlieb Archival Research Center</a></li>
-                        <li><a href="https://www.bu.edu/library/mugar-memorial/">Mugar Memorial Library</a></li>
-                        <li><a href="https://www.bu.edu/library/music/">Music Library</a></li>
-                        <!-- <li><a href="https://open.bu.edu/">OpenBU</a></li> -->
-                        <li><a href="https://www.bu.edu/library/management/">Pardee Management Library</a></li>
-                        <li><a href="https://www.bu.edu/library/pickering-educational/">Pickering Educational Resources Library</a></li>
-                        <li><a href="https://www.bu.edu/library/sel/">Science &amp; Engineering Library</a></li>
-                        <li><a href="https://www.bu.edu/library/stone-science/">Stone Science Library</a></li>
-                        <li><a href="https://www.bu.edu/library/about/additional-libraries/">Additional Libraries</a></li>
-                      </ul>
-                    </div>
-                  </div>
-                </li>
-                <li>
-                  <a class="menu-item inline" href="https://askalibrarian.bu.edu/">
-                    <span class="labeled-icon prl">Ask a Librarian</span><i class="material-icons inline">question_answer</i>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-        <script id="mobile-nav-clickout" type="text/javascript">
-          let input = document.querySelector("#menuToggle > input");
-          window.addEventListener("click", (event) => {
-            let clicked = event.target;
-            let clicked_within_mobile_menu = clicked.closest("#menuToggle") != null;
-            if(input && clicked != input && !clicked_within_mobile_menu || clicked.tagName == "A"){
-              input.checked = false; // uncheck the #menuToggle input, closing the mobile nav
-            }
-          });
-        </script>
-      </nav>
-    </div>
-    <div class="banner-wrapper">
-      <div class="banner">
-        <div>
-          <h1><a href="/az.php">A-Z Databases</a>&nbsp;</h1>
-          <div id="s-lib-bc">{{breadcrumbs}}</div>
-        </div>
-        
-        <bulib-search str_options="db guides primo"></bulib-search>
-      </div>
-    </div>
+    <div>{{public_header}}</div>
     <!-- END: Page Header -->
+
+    <!-- BEGIN: Content Header -->
+    <div id="s-lib-public-header" class="s-lib-header container s-lib-side-borders">
+      <div id="s-lib-bc">{{breadcrumbs}}</div>
+      <h1 id="s-lib-public-header-title">{{page_title}}</h1>
+      <div id="s-lib-public-header-desc">{{page_description}}</div>
+    </div>
+    <!-- END: Content Header -->
 
     <!-- BEGIN: Nav Bar -->
     <div id="s-lib-public-nav" class="container s-lib-side-borders">
@@ -124,7 +40,7 @@
           <div id="col1" class="col-lg-8 center">
             <div id="s-lg-az-filters" class="secondary-menu">
               <strong>Filter Database List:</strong>
-              <section id="s-lg-az-filter-cols" class="row">
+              <section id="s-lg-az-filter-cols" class="row mvs">
                 <div id="col-subjects" class="col-sm-3">{{subject_list}}</div>
                 <div class="col-sm-6">
                   <form class="flexw" role="search" onsubmit="springSpace.publicObj.filterAzBySearch(2345); return false;">

--- a/sites/libguides/azlist.html
+++ b/sites/libguides/azlist.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>A-Z Databases - Boston University Libraries</title>
+  </head>
+	<body class="s-lib-public-body">
+    
+    <!-- BEGIN: Page Header -->
+    <p>
+      {{skip_link}}
+      {{public_header}}
+    </p>
+    <!-- END: Page Header -->
+
+    <!-- BEGIN: Content Header -->
+    <div id="s-lib-public-header" class="s-lib-header container s-lib-side-borders">
+      <div id="s-lib-bc">{{breadcrumbs}}</div>
+      <h1 id="s-lib-public-header-title">{{page_title}}</h1>
+      <div id="s-lib-public-header-desc">{{page_description}}</div>
+    </div>
+    <!-- END: Content Header -->
+
+    <!-- BEGIN: Nav Bar -->
+    <div id="s-lib-public-nav" class="container s-lib-side-borders">
+      {{page_nav}}
+    </div>
+    <!-- END: Nav Bar -->
+    
+    <!-- BEGIN: content -->
+    <div id="s-lib-public-main" class="s-lib-main container s-lib-side-borders">
+      <section>
+        <div id="s-lg-az-search-bar" class="row">
+          <div id="az-search-col-1" class="col-md-12 center">
+            {{navbar}}
+          </div>
+        </div>
+      </section>
+      <section>
+        <div id="s-lg-az-cols" class="row">
+          <div id="col1" class="col-md-8 center">
+            <div id="s-lg-az-filters" class="pad-right-sm pad-bottom-med">
+              <section>
+                <div id="s-lg-az-filter-cols" class="row">
+                  <div id="col-subjects" class="col-md-4 center">
+                    {{subject_list}}
+                  </div>
+                  <div id="col-types" class="col-md-4 center">
+                    {{type_list}}
+                  </div>
+                  <div id="col-vendors" class="col-md-4 center">
+                    {{vendor_list}}
+                  </div>
+                </div>
+              </section>
+            </div>
+            <div id="s-lg-az-index" class="pad-right-sm">
+              {{alpha_list}}
+            </div>
+            <div>
+              <p>&nbsp;</p>
+              <p>
+                <strong>Note</strong>: Use the Subjects and Database Types drop-down menus to filter the list of databases.<br>
+                Databases in the <strong><a href="http://library.bu.edu/az.php?s=74044">Multidisciplinary</a></strong>,
+                <strong><a href="http://library.bu.edu/az.php?s=101186">Science (General)</a></strong>, and 
+                <strong><a href="http://library.bu.edu/az.php?s=101187">Humanities & Social Sciences (General)</a></strong>
+                subject categories will be useful for many subject areas
+              </p>
+              <img src="https://s3.amazonaws.com/libapps/sites/2345/icons/10444/Law2.jpg" hspace="3">= Available only on site at Pardee Library &nbsp;
+              <img src="https://s3.amazonaws.com/libapps/sites/2345/icons/10443/gavel.jpg" hspace="3"> = Law School only
+              <p>&nbsp;</p>
+            </div>
+            <div id="s-lg-az-search-reset" class="pad-top-med pad-bottom-med">
+              {{search_reset}}
+            </div>
+            <div id="s-lg-az-content" class="pad-right-sm pad-top-med">
+              <div class="bold s-lib-color-lt-grey pad-top-med text-center">
+                Loading...
+              </div>
+            </div>
+          </div>
+          <div id="col2" class="col-md-4 center">
+            <h4>Introducing Policy Map</h4>
+            <p>
+              <a href="https://bu-policymap-com.ezproxy.bu.edu/maps">Policy Map</a> 
+              is an easy-to-use online mapping and visualization tool. Downloadable U.S. demographic, economic and 
+              social data by city, state, zip code, county or census tract. Types of data include crime, housing, health, 
+              education and occupations, derived from both public and proprietary sources.
+            </p>
+            <p>
+              <a href="https://bu-policymap-com.ezproxy.bu.edu/maps?p=160454&amp;i=9873795&amp;btd=6.=2012-2016&amp;moo=otf_tractbounds_2010&amp;cx=-70.9973022320944&amp;cy=42.33721846499532&amp;cz=9">
+                <img src="https://libapps.s3.amazonaws.com/customers/2020/images/Policy_Map_example.png">
+              </a>
+            </p>
+            <p style="box-sizing: border-box; margin: 0px 0px 10px; font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size: 14px; text-align: center;">
+              &nbsp;
+            </p>{{trials_box}} {{content_box_experts}} {{content_box_guides}}
+          </div>
+        </div>
+      </section>
+    </div>
+    <!-- END: content -->
+    
+    <!-- BEGIN: Page Footer -->
+    <p>{{system_footer}} </p>
+    <!-- END: Page Footer -->
+    
+    <div id="s-lib-alert" title="">
+      <div id="s-lib-alert-content"></div>
+    </div>
+    <div id="s-lib-popover-title" class="hide">
+      <span class="text-info"><strong>title</strong></span> <button type="button" id="popclose" class="close" onclick="jQuery('.s-lib-popover').popover('hide')">×</button>
+    </div>
+    <div id="s-lib-popover-content" class="hide">
+      Loading... <button class="btn btn-default btn-sm popclose" type="button">Close</button>
+    </div>
+    <div id="s-lib-scroll-top" title="Back to Top">
+      <span class="fa-stack fa-lg"></span>
+    </div>
+    
+    <!-- BEGIN: Custom Footer -->
+    <p>{{public_footer}}</p>
+    <!-- END: Custom Footer -->
+  
+  </body>
+</html>

--- a/sites/libguides/azlist.html
+++ b/sites/libguides/azlist.html
@@ -183,7 +183,7 @@
     <!-- END: content -->
     
     <!-- BEGIN: Page Footer -->
-    <p>{{system_footer}} </p>
+    <div>{{system_footer}} </div>
     <!-- END: Page Footer -->
     
     <div id="s-lib-alert" title="">
@@ -200,7 +200,7 @@
     </div>
     
     <!-- BEGIN: Custom Footer -->
-    <p>{{public_footer}}</p>
+    <div>{{public_footer}}</div>
     <!-- END: Custom Footer -->
   
   </body>

--- a/sites/libguides/libguides.css
+++ b/sites/libguides/libguides.css
@@ -46,7 +46,7 @@
 
 /* color the 'Clear Filters' button to make it stand out more */
 #s-lg-az-search-reset button#s-lg-az-reset {
-  background-color: var(--color-button-background-light, #639CC9);
+  background-color: var(--color-button-background, #639CC9);
   color: var(--color-button-text-light, white);
 }
 

--- a/sites/libguides/libguides.css
+++ b/sites/libguides/libguides.css
@@ -1,9 +1,8 @@
 /* styling for the tags, staff login url, 'Powered by SpringShare' */
 #s-lib-footer-public {
-  font-size: small;  
-  background-color: var(--color-secondary-background, white) !important;
-  color: black !important;
-  border-top: none;
+  font-size: small; 
+  color: var(--color-primary-text, whitesmoke);
+  background-color: var(--color-primary-background, black);
 }
 .s-lib-footer a { font-weight: 700; }
 .s-lib-footer a:hover { 
@@ -24,7 +23,9 @@
   .get-help i { font-size: large !important; padding-right: 4px; } 
   .get-help span { font-size: small !important; padding-right: 0px; } 
   .get-help li { padding-bottom: 5px; }
+  .banner bulib-search { display: none; }
 }
 
 /* enable mobile header to open above the rest of the page */
-.s-lib-main, #s-lg-guide-main { z-index: unset; }
+.s-lib-main, #s-lg-guide-main { z-index: unset !important; margin-top: 10px !important; }
+#s-lib-admin-bc .breadcrumb, #s-lib-bc .breadcrumb { font-size: small; }

--- a/sites/libguides/libguides.css
+++ b/sites/libguides/libguides.css
@@ -25,3 +25,6 @@
   .get-help span { font-size: small !important; padding-right: 0px; } 
   .get-help li { padding-bottom: 5px; }
 }
+
+/* enable mobile header to open above the rest of the page */
+.s-lib-main, #s-lg-guide-main { z-index: unset; }

--- a/sites/libguides/libguides.css
+++ b/sites/libguides/libguides.css
@@ -1,3 +1,9 @@
+/* add some padding for the header and footer */
+#s-lib-public-main {
+  margin-top: 10px !important;
+  margin-bottom: 10px !important;
+}
+
 /* styling for the tags, staff login url, 'Powered by SpringShare' */
 #s-lib-footer-public {
   font-size: small; 
@@ -33,7 +39,7 @@
 /* - A-Z Database list - */
 
 /* enable mobile header to open above the rest of the page */
-.s-lib-main, #s-lg-guide-main { z-index: unset !important; margin-top: 10px !important; }
+.s-lib-main, #s-lg-guide-main { z-index: unset !important; }
 
 /* adjust breadcrumb size when added to the bulib custom banner */
 .banner #s-lib-admin-bc .breadcrumb, .banner #s-lib-bc .breadcrumb { font-size: small; }

--- a/sites/libguides/libguides.css
+++ b/sites/libguides/libguides.css
@@ -4,10 +4,13 @@
   color: var(--color-primary-text, whitesmoke);
   background-color: var(--color-primary-background, black);
 }
-.s-lib-footer a { font-weight: 700; }
-.s-lib-footer a:hover { 
+#s-lib-footer-public a { 
+  font-weight: 700; 
+  color: var(--color-primary-text, #B4BCC1);
   text-decoration: underline;
-  color: var(--color-secondary-text-dark, #B4BCC1) !important; 
+}
+#s-lib-footer-public a:hover { 
+  color: var(--color-primary-text-light, white); 
 }
 
 /* 'Get Help' box styling (contact-us) */
@@ -26,6 +29,32 @@
   .banner bulib-search { display: none; }
 }
 
+
+/* - A-Z Database list - */
+
 /* enable mobile header to open above the rest of the page */
 .s-lib-main, #s-lg-guide-main { z-index: unset !important; margin-top: 10px !important; }
-#s-lib-admin-bc .breadcrumb, #s-lib-bc .breadcrumb { font-size: small; }
+
+/* adjust breadcrumb size when added to the bulib custom banner */
+.banner #s-lib-admin-bc .breadcrumb, .banner #s-lib-bc .breadcrumb { font-size: small; }
+
+/* color the 'Clear Filters' button to make it stand out more */
+#s-lg-az-search-reset button#s-lg-az-reset {
+  background-color: var(--color-button-background-light, #639CC9);
+  color: var(--color-button-text-light, white);
+}
+
+/* decrease horizontal padding between alpha_list */
+#s-lg-az-index .btn-group>.btn-link { padding: 4.5px; }
+#s-lg-az-index div.btn-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+}
+
+/* remove set width restrictions for az-list filters */
+.secondary-menu #s-lg-sel-az-types, 
+  .secondary-menu #s-lg-sel-az-vendors, 
+  .secondary-menu #s-lg-sel-subjects { 
+    width: 100%; 
+}

--- a/src/announce/announce.test.js
+++ b/src/announce/announce.test.js
@@ -1,7 +1,7 @@
 import { html, fixture, expect } from '@open-wc/testing';
 
 import './bulib-announce';
-import { elementUpdated, waitUntil } from '@open-wc/testing-helpers';
+import { elementUpdated } from '@open-wc/testing-helpers';
 
 const elementIsHidden = (el) => { return el.offsetHeight == 0; }
 

--- a/src/header/banner.scss
+++ b/src/header/banner.scss
@@ -1,31 +1,37 @@
+/* overall styling with padding and shadow */ 
 .banner-wrapper {
   font-family: 'Benton', sans-serif;
   background: var(--color-secondary-background, rgba(200,200,200,0.3));
   border-bottom: 1px solid var(--color-secondary-background-dark, #C8C8C8);
   box-shadow: 0px 0px 0px 1px var(--color-secondary-background-dark);
+  padding: 10px;
 }
 
 .banner {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-
-  h1, span {
-    font-family: 'Benton', sans-serif;
-    font-weight: 400 !important;
-    color: var(--color-secondary-text, black);
+  align-items: center;
+  font-size: larger;
+  color: var(--color-secondary-text, black);
+  
+  /* overwrite font-weight for strong links */
+  strong > a, a:first-of-type { font-weight: 500; }
+  
+  /* adjust the font, style, margins of site banner text/links */ 
+  h1, span, strong {
+    font-family: 'Benton', sans-serif !important;
     font-size: x-large;
-    padding-right: 10px;
+    font-weight: 400; 
 
     a { 
       color: var(--color-secondary-text-dark, black); 
       text-decoration: none;
       cursor: pointer;
     }
-    a:last-child{ font-weight: 300; }
-
-    bulib-search { min-width: 350px; }
   }
-  
-  > *:last-child { max-width: 550px; }
+
+  /* ensure the bulib-search is displayed multi-row  */
+  > *:first-child { margin-bottom: 10px; }
+  > bulib-search { max-width: 550px; }
 }

--- a/src/header/banner.scss
+++ b/src/header/banner.scss
@@ -10,7 +10,7 @@
   flex-wrap: wrap;
   justify-content: space-between;
 
-  h1 {
+  h1, span {
     font-family: 'Benton', sans-serif;
     font-weight: 400 !important;
     color: var(--color-secondary-text, black);
@@ -27,5 +27,5 @@
     bulib-search { min-width: 350px; }
   }
   
-  > *:last-child { max-width: 450px; }
+  > *:last-child { max-width: 550px; }
 }

--- a/src/header/banner.scss
+++ b/src/header/banner.scss
@@ -10,13 +10,11 @@
   flex-wrap: wrap;
   justify-content: space-between;
 
-  h1, span {
+  h1 {
     font-family: 'Benton', sans-serif;
     font-weight: 400 !important;
     color: var(--color-secondary-text, black);
     font-size: x-large;
-    margin-top: 20px;
-    margin-bottom: 20px;
     padding-right: 10px;
 
     a { 
@@ -28,7 +26,6 @@
 
     bulib-search { min-width: 350px; }
   }
-
-  > *:first-child { display: flex; }
+  
   > *:last-child { max-width: 450px; }
 }

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -186,19 +186,19 @@ div.dropdown.menu-item {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between; }
-  .banner h1 {
+  .banner h1, .banner span {
     font-family: 'Benton', sans-serif;
     font-weight: 400 !important;
     color: var(--color-secondary-text, black);
     font-size: x-large;
     padding-right: 10px; }
-    .banner h1 a {
+    .banner h1 a, .banner span a {
       color: var(--color-secondary-text-dark, black);
       text-decoration: none;
       cursor: pointer; }
-    .banner h1 a:last-child {
+    .banner h1 a:last-child, .banner span a:last-child {
       font-weight: 300; }
-    .banner h1 bulib-search {
+    .banner h1 bulib-search, .banner span bulib-search {
       min-width: 350px; }
   .banner > *:last-child {
-    max-width: 450px; }
+    max-width: 550px; }

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -176,29 +176,35 @@ div.dropdown.menu-item {
   visibility: visible;
   opacity: 0.95;
   display: block; }
+/* overall styling with padding and shadow */
 .banner-wrapper {
   font-family: 'Benton', sans-serif;
   background: var(--color-secondary-background, rgba(200, 200, 200, 0.3));
   border-bottom: 1px solid var(--color-secondary-background-dark, #C8C8C8);
-  box-shadow: 0px 0px 0px 1px var(--color-secondary-background-dark); }
+  box-shadow: 0px 0px 0px 1px var(--color-secondary-background-dark);
+  padding: 10px; }
 
 .banner {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between; }
-  .banner h1, .banner span {
-    font-family: 'Benton', sans-serif;
-    font-weight: 400 !important;
-    color: var(--color-secondary-text, black);
+  justify-content: space-between;
+  align-items: center;
+  font-size: larger;
+  color: var(--color-secondary-text, black);
+  /* overwrite font-weight for strong links */
+  /* adjust the font, style, margins of site banner text/links */
+  /* ensure the bulib-search is displayed multi-row  */ }
+  .banner strong > a, .banner a:first-of-type {
+    font-weight: 500; }
+  .banner h1, .banner span, .banner strong {
+    font-family: 'Benton', sans-serif !important;
     font-size: x-large;
-    padding-right: 10px; }
-    .banner h1 a, .banner span a {
+    font-weight: 400; }
+    .banner h1 a, .banner span a, .banner strong a {
       color: var(--color-secondary-text-dark, black);
       text-decoration: none;
       cursor: pointer; }
-    .banner h1 a:last-child, .banner span a:last-child {
-      font-weight: 300; }
-    .banner h1 bulib-search, .banner span bulib-search {
-      min-width: 350px; }
-  .banner > *:last-child {
+  .banner > *:first-child {
+    margin-bottom: 10px; }
+  .banner > bulib-search {
     max-width: 550px; }

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -186,23 +186,19 @@ div.dropdown.menu-item {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between; }
-  .banner h1, .banner span {
+  .banner h1 {
     font-family: 'Benton', sans-serif;
     font-weight: 400 !important;
     color: var(--color-secondary-text, black);
     font-size: x-large;
-    margin-top: 20px;
-    margin-bottom: 20px;
     padding-right: 10px; }
-    .banner h1 a, .banner span a {
+    .banner h1 a {
       color: var(--color-secondary-text-dark, black);
       text-decoration: none;
       cursor: pointer; }
-    .banner h1 a:last-child, .banner span a:last-child {
+    .banner h1 a:last-child {
       font-weight: 300; }
-    .banner h1 bulib-search, .banner span bulib-search {
+    .banner h1 bulib-search {
       min-width: 350px; }
-  .banner > *:first-child {
-    display: flex; }
   .banner > *:last-child {
     max-width: 450px; }

--- a/src/header/header.stories.mdx
+++ b/src/header/header.stories.mdx
@@ -147,3 +147,30 @@ LibCal exception case in which the site is dual-purpose (has two landing pages).
     `}
   </Story>
 </Preview>
+
+<Preview>
+  <Story name="site-banner-libguides">
+    {html`
+      <div class="banner-wrapper">
+      <div class="banner">
+        <div>
+          <h1><a href="/az.php">A-Z Databases List</a>&nbsp;</h1>
+          <div id="s-lib-bc">
+            <ol id="s-lib-bc-list" class="breadcrumb">
+              <li id="s-lib-bc-customer">
+                <a title="Boston University Libraries" href="http://bu.edu/library">Boston University Libraries</a>
+              </li>
+              <li id="s-lib-bc-site">
+                <a title="Research" href="//library.bu.edu/">Research</a>
+              </li>
+              <li id="s-lib-bc-page" class="active">A-Z Databases</li>
+            </ol>
+          </div>
+        </div>
+        
+        <bulib-search str_options="db guides primo"></bulib-search>
+      </div>
+    </div>
+    `}
+  </Story>
+</Preview>

--- a/src/header/header.stories.mdx
+++ b/src/header/header.stories.mdx
@@ -122,7 +122,7 @@ Links for a hierarchy of '**parent**: child' (unless otherwise specified), and s
     {html`
       <div class="banner-wrapper">
         <div class="banner">
-          <span><a href="/">Ask a Librarian:</a>&nbsp; <a href="/businessFAQs">Business FAQs</a></span>
+          <span><a href="/">Ask a Librarian:</a> <a href="/businessFAQs">Business FAQs</a></span>
           <bulib-search str_options="pardee-help primo"></bulib-search>
         </div>
       </div>
@@ -135,13 +135,12 @@ LibCal exception case in which the site is dual-purpose (has two landing pages).
 <Preview>
   <Story name="site-banner-libcal">
     {html`
-      <style>
-        div.banner-wrapper.libcal > .banner { display: inline-block; font-weight: normal; }
-        div.banner-wrapper.libcal > .banner a { font-weight: 500 !important; }
-      </style>
-      <div class="banner-wrapper libcal">
+      <div class="banner-wrapper">
         <div class="banner">
-          <span><a href="/calendar">Events</a> &nbsp; and &nbsp; <a href="https://www.bu.edu/library/about/study-spaces">Reservations</a>&nbsp; </span>
+          <span>
+            <strong><a href="/calendar">Events</a></strong> &nbsp; and &nbsp;
+            <strong><a href="https://www.bu.edu/library/about/study-spaces">Reservations</a></strong>
+          </span>
         </div>
       </div>
     `}

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -113,7 +113,7 @@ export default class BULibSearch extends LitElement {
         @media only screen and (min-width: 300px){
           #bulib-search { padding: 10px; }
           .search-box > input, input[type=radio], .search-options > label { 
-            font-size: large !important; 
+            font-size: medium; 
           }
         }
       `


### PR DESCRIPTION
### Jira Tickets: 
- [WEB-246](https://bulibrary.atlassian.net/browse/WEB-246): standardize .banner styling 
- [WEB-282](https://bulibrary.atlassian.net/browse/WEB-282): gather filter controls into one place
- [WEB-284](https://bulibrary.atlassian.net/browse/WEB-284): assorted styling updates
- [WEB-289](https://bulibrary.atlassian.net/browse/WEB-289): create new custom 'A-Z Template'

### Background
- there were a number of issues/problems identified in the tickets
- this is for/on the libguides platform


### Description of Changes
- [x] create a new template for the az-list in `sites/libguides/azlist.html`
- [x] add new `.secondary-menu` style 
- [x] collect filter controls for the AZ List together
- [x] general styling enhancements

### Screenshots

#### WEB-246: `.banner` styling exception/standardization and improvements

_vertically center_
![vertically center](https://user-images.githubusercontent.com/5565284/73300913-d2e5a800-41df-11ea-8d27-fbd89f6a3bd8.png)

_libcal exception and remove extra style requirements, accommodate xlarge screens_
![xlarge screen ](https://user-images.githubusercontent.com/5565284/73301151-425b9780-41e0-11ea-8b71-bf08398ec5c8.png)


#### WEB-289: new database list template in libguides admin

![screenshot of libguides administrative panel](https://user-images.githubusercontent.com/5565284/73217622-44f9b680-4126-11ea-9972-e810da2b5859.png)


#### WEB-282: rearrange filter items into one spot

BEFORE:
![before](https://user-images.githubusercontent.com/5565284/73218494-111f9080-4128-11ea-968b-a93b3a14e592.png)

AFTER:
![screenshot of rearranged](https://user-images.githubusercontent.com/5565284/73218194-7c1c9780-4127-11ea-85c7-a819250900bc.png)

