### PR TITLE
WEB-300: move footer to the bottom of the viewport

### DIFF
--- a/assets/css/layouts.css
+++ b/assets/css/layouts.css
@@ -35,3 +35,10 @@ div.tiles > * {
 .flexw, .bulib-row { display: flex; flex-wrap: wrap; }
 .left { float: left; }
 .inline { display: inline-block; }
+
+/* - prepare footer to auto-margin itself to the bottom of the viewport - */
+body {
+  display: flex; 
+  flex-direction: column; 
+  min-height: 100vh;
+}

--- a/sites/libanswers/libanswers.css
+++ b/sites/libanswers/libanswers.css
@@ -1,4 +1,4 @@
-  /* -- General (all) -- */
+  /* -- libanswers (askalibrarian.bu.edu) -- */
 
   /* hide various */ 
   .s-la-public-header-text, /* hide automatic headers (replaced by banner text) */
@@ -18,6 +18,9 @@
     margin-top: auto; 
     margin-bottom: auto;
   }
+
+  /* move footer to the bottom of the viewport */
+  #footer { margin-top: auto; }
 
 
   /* -- FAQ page (/faq/) -- */

--- a/sites/libguides/libguides.css
+++ b/sites/libguides/libguides.css
@@ -1,8 +1,13 @@
+/* -- libguides (library.bu.edu/guides) -- */
+
 /* add some padding for the header and footer */
 #s-lib-public-main {
   margin-top: 10px !important;
   margin-bottom: 10px !important;
 }
+
+/* move footer to the bottom of the viewport */
+#s-lib-footer-public { margin-top: auto; }
 
 /* styling for the tags, staff login url, 'Powered by SpringShare' */
 #s-lib-footer-public {

--- a/sites/wordpress/wordpress.css
+++ b/sites/wordpress/wordpress.css
@@ -1,8 +1,18 @@
+/* -- wordpress (bu.edu/library) -- */
+
 /* adjustments to theme variables */
 body { --color-primary-background: #212121; }
 
+/* - footer styling - */
+#footer { 
+  /* match footer color in the padding placed around the footer */
+  background-color: var(--color-primary-background, black) !important; 
+
+  /* move footer to the bottom of the viewport */
+  margin-top: auto;
+}
+
 /* prevent overflow of footer width to 900px at small widths */
-#footer { background-color: var(--color-primary-background, black) !important; }
 #footer > div.container { 
   width: auto; 
   background-color: var(--color-primary-background, black);


### PR DESCRIPTION
Jira Ticket: [WEB-300](https://bulibrary.atlassian.net/browse/WEB-300)


### Description of Changes
use `flex`, `100vh`, and `margin-top: auto` to place the footer at the bottom of the viewport 

_NOTE: this only affects pages with very limited content_ 

### Screenshots 
[askalibrarian FAQ](https://askalibrarian.bu.edu/faq/20974), 
![screenshot before/after askalibrarian](https://user-images.githubusercontent.com/5565284/75269756-68685d80-57c7-11ea-9846-ca71e0a7910a.png)


[suggest a purchase interstitial page](http://www-staging.bu.edu/library/research/collections/collection-development/suggest-a-purchase/)
![screenshot before/after libguides](https://user-images.githubusercontent.com/5565284/75269896-aa919f00-57c7-11ea-9856-3bc680ccaa88.png)
