### PR TITLE
WEB-272: Connect 'bulib-announce' to Google Sheets API

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -233,7 +233,7 @@
         },
         {
           "name": "val",
-          "description": "css variable set somewhere within the scope and visible via var() (e.g. '--color-accent-background' )",
+          "description": "css variable set somewhere within the scope and visible via var() (e.g. '--color-accent-red-background' )",
           "type": "string"
         },
         {
@@ -252,7 +252,7 @@
         {
           "name": "val",
           "attribute": "val",
-          "description": "css variable set somewhere within the scope and visible via var() (e.g. '--color-accent-background' )",
+          "description": "css variable set somewhere within the scope and visible via var() (e.g. '--color-accent-red-background' )",
           "type": "string"
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulib-wc",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "description": "collection of web components and styles used at Boston University Libraries",
   "type": "module",
   "main": "src/index.js",

--- a/src/_helpers/storageUtility.js
+++ b/src/_helpers/storageUtility.js
@@ -1,6 +1,6 @@
 
 const DEBUG = true;
-const DEFAULT_STORAGE_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7; // 1 week
+const DEFAULT_STORAGE_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 1; // 1 day (for now)
 
 function _logToConsole(msg){ if(DEBUG){ console.log("_storageUtility) " + msg); }}
 

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -166,18 +166,19 @@ Below are all the `code`s that we have pre-prepared for this purpose:
           <th>code</th><th>banner</th>
         </thead>
         <tbody>
-          <tr><td>all</td><td><bulib-announce debug dismissed code="all"></bulib-announce></td></tr>
-          <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
           <tr><td>primo-BU</td><td><bulib-announce debug dismissed code="primo-BU"></bulib-announce></td></tr>
+          <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
           <tr><td>primo-BULAW</td><td><bulib-announce debug dismissed code="primo-BULAW"></bulib-announce></td></tr>
           <tr><td>primo-ISL</td><td><bulib-announce debug dismissed code="primo-ISL"></bulib-announce></td></tr>
           <tr><td>primo-test</td><td><bulib-announce debug dismissed code="primo-test"></bulib-announce></td></tr>
           <tr><td>testing</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>
           <tr><td>wordpress</td><td><bulib-announce debug dismissed code="wordpress"></bulib-announce></td></tr>
           <tr><td>libguides</td><td><bulib-announce debug dismissed code="libguides"></bulib-announce></td></tr>
+          <tr><td>libcal</td><td><bulib-announce debug dismissed code="libcal"></bulib-announce></td></tr>
           <tr><td>libanswers</td><td><bulib-announce debug dismissed code="libanswers"></bulib-announce></td></tr>
           <tr><td>libanswers-business</td><td><bulib-announce debug dismissed code="libanswers-business"></bulib-announce></td></tr>
-          <tr><td>libcal</td><td><bulib-announce debug dismissed code="libcal"></bulib-announce></td></tr>
+          <tr><td>libanswers-spring2020</td><td><bulib-announce debug dismissed code="libanswers-spring2020"></bulib-announce></td></tr>
+          <tr><td>all</td><td><bulib-announce debug dismissed code="all"></bulib-announce></td></tr>
         </tbody>
       </table>
     `}

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -121,8 +121,36 @@ You can see in the example below that when the API variable is set, but the user
   <Story name="sheets-api-default">
     {html`
       <table>
-        <tr><td>debug</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>
-        <tr><td>no debug</td><td><bulib-announce code="testing"></bulib-announce></td></tr>
+        <tr>
+          <td>debug</td>
+          <td><bulib-announce code="testing" message="this will be replaced" debug dismissed></bulib-announce></td>
+        </tr>
+        <tr>
+          <td>no debug</td>
+          <td><bulib-announce code="testing" message="this will be replaced" dismissed></bulib-announce></td>
+        </tr>
+      </table>
+    `}
+  </Story>
+</Preview>
+
+#### Disabling the Lookup for debugging
+
+
+You can use the `prevent_action` to stop th
+
+<Preview withToolbar>
+  <Story name="sheets-api-disabled">
+    {html`
+      <table>
+        <tr>
+          <td>debug</td>
+          <td><bulib-announce debug code="testing" message="api call prevented by 'prevent_action'" prevent_action></bulib-announce></td>
+        </tr>
+        <tr>
+          <td>no debug</td>
+          <td><bulib-announce code="testing"  message="api call prevented by 'prevent_action'" prevent_action></bulib-announce></td>
+        </tr>
       </table>
     `}
   </Story>

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -155,8 +155,8 @@ Below are all the `code`s that we have pre-prepared for this purpose:
           <th>code</th><th>banner</th>
         </thead>
         <tbody>
-          <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
           <tr><td>primo-BU</td><td><bulib-announce debug dismissed code="primo-BU"></bulib-announce></td></tr>
+          <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
           <tr><td>primo-BULAW</td><td><bulib-announce debug dismissed code="primo-BULAW"></bulib-announce></td></tr>
           <tr><td>primo-ISL</td><td><bulib-announce debug dismissed code="primo-ISL"></bulib-announce></td></tr>
           <tr><td>testing</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -65,10 +65,29 @@ In order to not annoy the user (by presenting them with irrelevant or unwanted i
   messages can be hidden by being dismissed (by setting them to `disabled`).
 
 
-#### Session Memory (default)
+#### Manual Override
 
-By default, we try to remember which banners have and haven't been dismissed by using the `src/_helpers/storageUtility`,
-  and look into the user's `localStorage` for the `announce-dismissal` for that specific `code`. 
+For debugging purposes, this can be done manually - in which case it will _always_ be hidden (`dismissed="true"`, `dismissed`) 
+  or _always_ shown (`dismissed="false"`) regardless of what's been saved in the local storage.
+
+<Preview withToolbar>
+  <Story name="dismissed-manual-override">
+    {html`
+      <bulib-announce debug code="dismissed-present" dismissed message="'dismissed' is present, but unspecified"></bulib-announce> <hr />
+      <bulib-announce debug code="dismissed-true" dismissed="true" message="'dismissed' is present and set to 'true'"></bulib-announce> <hr />
+      <bulib-announce debug code="dismissed-false" dismissed="false" message="'dismissed' is present and set to 'false'"></bulib-announce>
+    `}
+  </Story>
+</Preview>
+
+_NOTE: clicking the DISMISS button will immediately toggle the `dismiss` value for the banner, save that value in local storage, and switch that banner's dismissal to manual mode until page is reloaded_
+
+
+#### Looking at Session Memory (default)
+
+By default, we try to remember a user's decision to dismiss a banner for one week (seven days). 
+
+_NOTE: We 'remember' the user's decision by using the `src/_helpers/storageUtility` which reads from `localStorage`_ 
 
 <Preview withToolbar>
   <Story name="dismissed-memory">
@@ -81,23 +100,73 @@ By default, we try to remember which banners have and haven't been dismissed by 
   </Story>
 </Preview>
 
+### Getting Data from the Google Sheets API 
 
-#### Manual Override
+Often for emergency, convenience, inclusivity of authorship, etc., we want to have an announce-banner without 
+  having to add any additional `html` to our sites. 
 
-For debugging purposes, this can be done manually - in which case it will _always_ be hidden (`dismissed="true"`, `dismissed`) 
-  or _always_ shown (`dismissed="false"`) regardless of what's been saved in the local storage.
+#### Looking at the Default Code
+
+To do this, we add a `<bulib-announce>` tag with a particular `code`, referring to an entry in our 
+  ['announcment-banner' spreadsheet](https://docs.google.com/spreadsheets/d/1ElW0CUOV3LvcHuYxK2BZfFjo65a-XDrlNJtnrelA6tM/edit#gid=0).
+  This tag sits then asks that spreadsheet for what it should contain every time the page loads, but only shows itself to the user
+  when the `show_banner` is checked _and_ they haven't dismissed it. 
+
+We'll use the `testing` code for this example, since we normally leave that one selected.
+
+You can see in the example below that when the API variable is set, but the user has already dismissed the banner 
+  within the default expiration, it's still hidden.
 
 <Preview withToolbar>
-  <Story name="dismissed-override">
+  <Story name="sheets-api-default">
     {html`
-      <bulib-announce debug code="dismissed-present" dismissed message="'dismissed' is present, but unspecified"></bulib-announce> <hr />
-      <bulib-announce debug code="dismissed-true" dismissed="true" message="'dismissed' is present and set to 'true'"></bulib-announce> <hr />
-      <bulib-announce debug code="dismissed-false" dismissed="false" message="'dismissed' is present and set to 'false'"></bulib-announce>
+      <table>
+        <tr><td>debug</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>
+        <tr><td>no debug</td><td><bulib-announce code="testing"></bulib-announce></td></tr>
+      </table>
     `}
   </Story>
 </Preview>
 
-_NOTE: clicking the DISMISS button will immediately toggle the `dismiss` value for the banner, save that value in local storage, and switch that banner's dismissal to manual mode until page is reloaded_
+
+#### Existing Platform Codes
+
+By convention, we do this for each of our bigger platforms; adding one of the following tags with it's specified `code` 
+  just below the header, and letting it wait for when it should be shown. 
+  
+If we wanted to add an announce-banner to the [Database List](https://library.bu.edu/az.php), for example, we'd look
+  for the that entry in the google spreadsheet (`libguides-db` in this case), and add the following code to the 
+  header for that platform.
+
+```html
+<bulib-announce code="libguides-db"></bulib-announce>
+``` 
+
+We'd then see any of the edits we made in the spreadsheet reflected on every page of that 
+  platform (when `show_banner` is checked or we have `debug` attribute on).
+
+Below are all the `code`s that we have pre-prepared for this purpose: 
+
+<Preview withToolbar>
+  <Story name="sheets-api-enumerated">
+    {html`
+      <table>
+        <thead>
+          <th>code</th><th>banner</th>
+        </thead>
+        <tbody>
+          <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
+          <tr><td>testing</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>
+          <tr><td>wordpress</td><td><bulib-announce debug dismissed code="wordpress"></bulib-announce></td></tr>
+          <tr><td>libguides</td><td><bulib-announce debug dismissed code="libguides"></bulib-announce></td></tr>
+          <tr><td>libguides-db</td><td><bulib-announce debug dismissed code="libguides-db"></bulib-announce></td></tr>
+          <tr><td>libanswers</td><td><bulib-announce debug dismissed code="libanswers"></bulib-announce></td></tr>
+          <tr><td>libcal</td><td><bulib-announce debug dismissed code="libcal"></bulib-announce></td></tr>
+        </tbody>
+      </table>
+    `}
+  </Story>
+</Preview>
 
 
 ## API - Properties 

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -156,11 +156,15 @@ Below are all the `code`s that we have pre-prepared for this purpose:
         </thead>
         <tbody>
           <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
+          <tr><td>primo-BU</td><td><bulib-announce debug dismissed code="primo-BU"></bulib-announce></td></tr>
+          <tr><td>primo-BULAW</td><td><bulib-announce debug dismissed code="primo-BULAW"></bulib-announce></td></tr>
+          <tr><td>primo-ISL</td><td><bulib-announce debug dismissed code="primo-ISL"></bulib-announce></td></tr>
           <tr><td>testing</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>
           <tr><td>wordpress</td><td><bulib-announce debug dismissed code="wordpress"></bulib-announce></td></tr>
           <tr><td>libguides</td><td><bulib-announce debug dismissed code="libguides"></bulib-announce></td></tr>
           <tr><td>libguides-db</td><td><bulib-announce debug dismissed code="libguides-db"></bulib-announce></td></tr>
           <tr><td>libanswers</td><td><bulib-announce debug dismissed code="libanswers"></bulib-announce></td></tr>
+          <tr><td>libanswers-business</td><td><bulib-announce debug dismissed code="libanswers-business"></bulib-announce></td></tr>
           <tr><td>libcal</td><td><bulib-announce debug dismissed code="libcal"></bulib-announce></td></tr>
         </tbody>
       </table>

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -15,6 +15,7 @@ import './bulib-announce.js';
 Used to show site-wide, time-sensitive, dismissable chunk of information with varying severity, a prominent message, 
   and a clear call to action.
 
+
 ## Usages 
 
 ### Default Component
@@ -26,6 +27,7 @@ by default, `bulib-announce` displays with a default message with an `info`-leve
     {html`<bulib-announce debug></bulib-announce>`}
   </Story>
 </Preview>
+
 
 ### Custom Message and Severity
 
@@ -44,6 +46,7 @@ Specifying a `severity` will alter its color and icon, and should be complimenta
     `}
   </Story>
 </Preview>
+
 
 ### Custom Calls-to-Actions
 
@@ -100,10 +103,12 @@ _NOTE: We 'remember' the user's decision by using the `src/_helpers/storageUtili
   </Story>
 </Preview>
 
+
 ### Getting Data from the Google Sheets API 
 
 Often for emergency, convenience, inclusivity of authorship, etc., we want to have an announce-banner without 
   having to add any additional `html` to our sites. 
+
 
 #### Looking at the Default Code
 
@@ -128,28 +133,6 @@ You can see in the example below that when the API variable is set, but the user
         <tr>
           <td>no debug</td>
           <td><bulib-announce code="testing" message="this will be replaced" dismissed></bulib-announce></td>
-        </tr>
-      </table>
-    `}
-  </Story>
-</Preview>
-
-#### Disabling the Lookup for debugging
-
-
-You can use the `prevent_action` to stop th
-
-<Preview withToolbar>
-  <Story name="sheets-api-disabled">
-    {html`
-      <table>
-        <tr>
-          <td>debug</td>
-          <td><bulib-announce debug code="testing" message="api call prevented by 'prevent_action'" prevent_action></bulib-announce></td>
-        </tr>
-        <tr>
-          <td>no debug</td>
-          <td><bulib-announce code="testing"  message="api call prevented by 'prevent_action'" prevent_action></bulib-announce></td>
         </tr>
       </table>
     `}
@@ -201,6 +184,27 @@ Below are all the `code`s that we have pre-prepared for this purpose:
   </Story>
 </Preview>
 
+
+#### Preventing/Disabling the API Call Lookup (debugging)
+
+You can use the `prevent_action` to stop the call to the Sheets API.
+
+<Preview withToolbar>
+  <Story name="sheets-api-prevented">
+    {html`
+      <table>
+        <tr>
+          <td>debug</td>
+          <td><bulib-announce debug code="testing" message="api call prevented by 'prevent_action'" prevent_action></bulib-announce></td>
+        </tr>
+        <tr>
+          <td>no debug</td>
+          <td><bulib-announce code="testing"  message="api call prevented by 'prevent_action'" prevent_action></bulib-announce></td>
+        </tr>
+      </table>
+    `}
+  </Story>
+</Preview>
 
 ## API - Properties 
 

--- a/src/announce/announce-wc.stories.mdx
+++ b/src/announce/announce-wc.stories.mdx
@@ -155,14 +155,15 @@ Below are all the `code`s that we have pre-prepared for this purpose:
           <th>code</th><th>banner</th>
         </thead>
         <tbody>
-          <tr><td>primo-BU</td><td><bulib-announce debug dismissed code="primo-BU"></bulib-announce></td></tr>
+          <tr><td>all</td><td><bulib-announce debug dismissed code="all"></bulib-announce></td></tr>
           <tr><td>primo</td><td><bulib-announce debug dismissed code="primo"></bulib-announce></td></tr>
+          <tr><td>primo-BU</td><td><bulib-announce debug dismissed code="primo-BU"></bulib-announce></td></tr>
           <tr><td>primo-BULAW</td><td><bulib-announce debug dismissed code="primo-BULAW"></bulib-announce></td></tr>
           <tr><td>primo-ISL</td><td><bulib-announce debug dismissed code="primo-ISL"></bulib-announce></td></tr>
+          <tr><td>primo-test</td><td><bulib-announce debug dismissed code="primo-test"></bulib-announce></td></tr>
           <tr><td>testing</td><td><bulib-announce debug dismissed code="testing"></bulib-announce></td></tr>
           <tr><td>wordpress</td><td><bulib-announce debug dismissed code="wordpress"></bulib-announce></td></tr>
           <tr><td>libguides</td><td><bulib-announce debug dismissed code="libguides"></bulib-announce></td></tr>
-          <tr><td>libguides-db</td><td><bulib-announce debug dismissed code="libguides-db"></bulib-announce></td></tr>
           <tr><td>libanswers</td><td><bulib-announce debug dismissed code="libanswers"></bulib-announce></td></tr>
           <tr><td>libanswers-business</td><td><bulib-announce debug dismissed code="libanswers-business"></bulib-announce></td></tr>
           <tr><td>libcal</td><td><bulib-announce debug dismissed code="libcal"></bulib-announce></td></tr>

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -9,9 +9,9 @@ const codes_that_map_to_api_entry = {
   "testing": 6,
   "wordpress": 7,
   "libguides": 8, 
-  "libanswers": 10, "libanswers-business": 11,
-  "libcal": 9,
-  "all": 13, "covid-19": 13
+  "libcal": 9, 
+  "libanswers": 10, "libanswers-business": 11, "libanswers-spring2020": 12,
+  "all": 13
 }
 
 const primo_specific_padding = html`

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -56,9 +56,17 @@ export default class BULAnnounce extends LitElement {
   /** when first connected, iff there's a special code, set contents based on the API */
   connectedCallback(){
     super.connectedCallback();
-    if(this.code in codes_that_map_to_api_entry && !this.prevent_action){
-      this._logToConsole(`code '${this.code}' in codes_that_map. making a call to the Sheets API`);
-      this.dismissed = true;  // default to dismissed (don't flash before/during the API call)
+    if(this.code in codes_that_map_to_api_entry){
+      this._logToConsole(`code '${this.code}' in codes_that_map dictionary.`);
+      if(this.prevent_action){ 
+        this._logToConsole("'prevent_action' stopped the API from being called!"); 
+        return;
+      }
+      else{
+        this.dismissed = true;  // default to dismissed (don't flash before/during the API call)
+        this._logToConsole(`making a call to the SheetsAPI for '${this.code}'.`);
+      }
+      
       let row_id = codes_that_map_to_api_entry[this.code];
       fetch('https://spreadsheets.google.com/feeds/list/'+google_sheets_document_id+'/1/public/values?alt=json', { method:'GET', mode:'cors', cache:'no-store' })
         .then(response => response.json())

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -5,15 +5,12 @@ import {readExpiringLocalValue, setExpiringLocalValue} from '../_helpers/storage
 /* references to google sheets API and the entries within it */
 const google_sheets_document_id = '1ElW0CUOV3LvcHuYxK2BZfFjo65a-XDrlNJtnrelA6tM';
 const codes_that_map_to_api_entry = {
-  "primo": 0, 
-  "primo-BU": 1,
-  "primo-BULAW": 2,
+  "primo-BU": 0, "primo": 1, "primo-BULAW": 2, "primo-journals": 3, "primo-london": 4, "primo-ISL": 5,
   "testing": 6,
   "wordpress": 7,
-  "libguides": 8,
-  "libguides-db": 9,
-  "libanswers": 10,
-  "libcal": 11
+  "libguides": 8, "libguides-db": 9,
+  "libanswers": 10, "libanswers-business": 11,
+  "libcal": 12
 }
 
 const primo_specific_padding = html`

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -2,6 +2,20 @@ import {LitElement, html} from 'lit-element/lit-element';
 
 import {readExpiringLocalValue, setExpiringLocalValue} from '../_helpers/storageUtility';
 
+/* references to google sheets API and the entries within it */
+const google_sheets_document_id = '1ElW0CUOV3LvcHuYxK2BZfFjo65a-XDrlNJtnrelA6tM';
+const codes_that_map_to_api_entry = {
+  "primo": 0, 
+  "primo-BU": 1,
+  "primo-BULAW": 2,
+  "testing": 6,
+  "wordpress": 7,
+  "libguides": 8,
+  "libguides-db": 9,
+  "libanswers": 10,
+  "libcal": 11
+}
+
 const primo_specific_padding = html`
   <style type="text/css">
     /* site-specific code for primo's announce-banner.js - adds padding below the search bar */ 
@@ -39,6 +53,36 @@ export default class BULAnnounce extends LitElement {
       /** (debugging) disable show/hide check, cta  */
       prevent_action: {type: Boolean}
     };
+  }
+
+  /** when first connected, iff there's a special code, set contents based on the API */
+  connectedCallback(){
+    super.connectedCallback();
+    if(this.code in codes_that_map_to_api_entry){
+      this.dismissed = true;  // default to dismissed (don't flash before/during the API call)
+      let row_id = codes_that_map_to_api_entry[this.code];
+      fetch('https://spreadsheets.google.com/feeds/list/'+google_sheets_document_id+'/1/public/values?alt=json', { method:'GET', mode:'cors' })
+        .then(response => response.json())
+        .then(json => json.feed.entry[row_id])
+        .then(data => this._setDataHelperWithDataFromAPI(data));
+    }
+  }
+
+  /** helper that updates the components information with the Sheets its given */
+  _setDataHelperWithDataFromAPI(data){
+    this._logToConsole(data);
+
+    // un-dismiss if the 'show_banner' checkbox has been selected
+    if(data.gsx$showbanner.$t == "TRUE"){ this.dismissed = false; }
+
+    // set the message from the API, but try not 
+    let message = data.gsx$messagetext.$t;
+    if(message.length > 0){ this.message = message; }
+    
+    // set additional data
+    this.cta_url = data.gsx$messagelink.$t;
+    this.severity = data.gsx$messageseverity.$t || 'info';
+    this.cta_text = data.gsx$ctatext.$t;
   }
 
   render(){

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -56,7 +56,8 @@ export default class BULAnnounce extends LitElement {
   /** when first connected, iff there's a special code, set contents based on the API */
   connectedCallback(){
     super.connectedCallback();
-    if(this.code in codes_that_map_to_api_entry){
+    if(this.code in codes_that_map_to_api_entry && !this.prevent_action){
+      this._logToConsole(`code '${this.code}' in codes_that_map. making a call to the Sheets API`);
       this.dismissed = true;  // default to dismissed (don't flash before/during the API call)
       let row_id = codes_that_map_to_api_entry[this.code];
       fetch('https://spreadsheets.google.com/feeds/list/'+google_sheets_document_id+'/1/public/values?alt=json', { method:'GET', mode:'cors', cache:'no-store' })
@@ -68,9 +69,10 @@ export default class BULAnnounce extends LitElement {
 
   /** helper that updates the components information with the Sheets its given */
   _setDataHelperWithDataFromAPI(data){
-    this._logToConsole(data);
+    this._logToConsole(`'show_banner' in the google sheets for '${this.code}' is '${data.gsx$showbanner.$t}'.`);
 
     // un-dismiss if the 'show_banner' checkbox has been selected
+    let before = this.dismissed;
     if(data.gsx$showbanner.$t == "TRUE"){ this.dismissed = false; }
 
     // set the message from the API, but try not 
@@ -83,7 +85,7 @@ export default class BULAnnounce extends LitElement {
     this.cta_text = data.gsx$ctatext.$t;
 
     // manually trigger a re-render 
-    this.requestUpdate();
+    this.requestUpdate("dismissed", before);
   }
 
   render(){

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -5,12 +5,13 @@ import {readExpiringLocalValue, setExpiringLocalValue} from '../_helpers/storage
 /* references to google sheets API and the entries within it */
 const google_sheets_document_id = '1ElW0CUOV3LvcHuYxK2BZfFjo65a-XDrlNJtnrelA6tM';
 const codes_that_map_to_api_entry = {
-  "primo-BU": 0, "primo": 1, "primo-BULAW": 2, "primo-journals": 3, "primo-london": 4, "primo-ISL": 5,
+  "primo-BU": 0, "primo": 1, "primo-BULAW": 2, "primo-journals": 3, "primo-test": 4, "primo-ISL": 5,
   "testing": 6,
   "wordpress": 7,
-  "libguides": 8, "libguides-db": 9,
+  "libguides": 8, 
   "libanswers": 10, "libanswers-business": 11,
-  "libcal": 12
+  "libcal": 9,
+  "all": 13, "covid-19": 13
 }
 
 const primo_specific_padding = html`

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -59,7 +59,7 @@ export default class BULAnnounce extends LitElement {
     if(this.code in codes_that_map_to_api_entry){
       this.dismissed = true;  // default to dismissed (don't flash before/during the API call)
       let row_id = codes_that_map_to_api_entry[this.code];
-      fetch('https://spreadsheets.google.com/feeds/list/'+google_sheets_document_id+'/1/public/values?alt=json', { method:'GET', mode:'cors' })
+      fetch('https://spreadsheets.google.com/feeds/list/'+google_sheets_document_id+'/1/public/values?alt=json', { method:'GET', mode:'cors', cache:'no-store' })
         .then(response => response.json())
         .then(json => json.feed.entry[row_id])
         .then(data => this._setDataHelperWithDataFromAPI(data));
@@ -81,6 +81,9 @@ export default class BULAnnounce extends LitElement {
     this.cta_url = data.gsx$messagelink.$t;
     this.severity = data.gsx$messageseverity.$t || 'info';
     this.cta_text = data.gsx$ctatext.$t;
+
+    // manually trigger a re-render 
+    this.requestUpdate();
   }
 
   render(){

--- a/src/announce/announce.js
+++ b/src/announce/announce.js
@@ -72,8 +72,10 @@ export default class BULAnnounce extends LitElement {
     this._logToConsole(`'show_banner' in the google sheets for '${this.code}' is '${data.gsx$showbanner.$t}'.`);
 
     // un-dismiss if the 'show_banner' checkbox has been selected
-    let before = this.dismissed;
-    if(data.gsx$showbanner.$t == "TRUE"){ this.dismissed = false; }
+    if(data.gsx$showbanner.$t == "TRUE"){ 
+      this.dismissed = false; 
+      this.removeAttribute("dismissed");
+    }
 
     // set the message from the API, but try not 
     let message = data.gsx$messagetext.$t;
@@ -83,9 +85,6 @@ export default class BULAnnounce extends LitElement {
     this.cta_url = data.gsx$messagelink.$t;
     this.severity = data.gsx$messageseverity.$t || 'info';
     this.cta_text = data.gsx$ctatext.$t;
-
-    // manually trigger a re-render 
-    this.requestUpdate("dismissed", before);
   }
 
   render(){
@@ -145,7 +144,7 @@ export default class BULAnnounce extends LitElement {
 
     // ensure the component updates (re-renders) and hides (or shows) the component
     this._logToConsole(`dismiss clicked, session's' '${this._dismissedId()}' value '${value_before}'->'${this._getDismissedValue()}'`);
-    this.requestUpdate();
+    this.requestUpdate("dismissed", value_before);
 
     // save this updated setting in the localStorage
     setExpiringLocalValue(this._dismissedId(), !value_before);

--- a/src/announce/announce.test.js
+++ b/src/announce/announce.test.js
@@ -53,4 +53,15 @@ describe('bulib-announce', () => {
     innerDiv = el.querySelector("div.announce-banner");
     expect(elementIsHidden(innerDiv)).to.be.true;
   });
+
+  it("adding 'prevent_action' with an api-enabled code stops from loading API values", async () => {
+    let el = await fixture(html`<bulib-announce debug code="primo" message="original message" prevent_action></bulib-announce>`);
+    await elementUpdated(el);
+    
+    // click on the dismiss button and wait for the element to update
+    let innerMessage = el.querySelector("div.announce-banner > .message");
+
+    // assert that the innerHTML changes and that the banner becomes hidden
+    expect(innerMessage.innerText).to.include("original");
+  });
 });

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -219,8 +219,8 @@ export default class BULibFooter extends LitElement {
               </div>
               <div>
                 <ul class="no-bullet inline-list ptl">
-                  <li><a title="Libraries Home" class="white-link" href="https://www.bu.edu/library/"
-                          @click="${(ev) => {sendGAEventFromClickEvent(ev, 'bulib-footer');}}">Home</a></li>
+                  <li><a title="Boston University Home Page" class="white-link" href="https://www.bu.edu/"
+                          @click="${(ev) => {sendGAEventFromClickEvent(ev, 'bulib-footer');}}">BU Home</a></li>
                   <li><a title="Search available/licensed content" class="white-link" href="https://www.bu.edu/library/search"
                           @click="${(ev) => {sendGAEventFromClickEvent(ev, 'bulib-footer');}}">Search</a></li>
                   <li><a title="Information regarding various BU Libraries" class="white-link" href="https://www.bu.edu/library/about"

--- a/src/search/search_options.js
+++ b/src/search/search_options.js
@@ -1,6 +1,7 @@
 /** data on the overall search sources we have available to search on */
 export const search_options = [
   {"value":"help",        "name":"Help Topics",              "placeholder": "Search for help topics",           "domain":"https://askalibrarian.bu.edu/search/?t=0&q="},
+  {"value":"help-spr20",  "name":"Spring 2020 Help Topics",  "placeholder": "Search for help topics",           "domain":"https://askalibrarian.bu.edu/spring2020/search/?t=0&g=7265&q"},
   {"value":"pardee-help", "name":"Business FAQs",            "placeholder": "Search for business help topics",  "domain":"https://askalibrarian.bu.edu/businessFAQs/search/?t=0&q="},
   {"value":"primo",       "name":"BU Libraries Search",      "placeholder": "Search library resources",         "domain":"https://buprimo.hosted.exlibrisgroup.com/primo-explore/search?vid=BU&institution=BOSU&search_scope=default_scope&highlight=true&lang=en_US&query=any,contains,"},
   {"value":"wp",          "name":"BU Libraries Site",        "placeholder": "Search library info/services",     "domain":"https://search.bu.edu/?site=www.bu.edu%2Flibrary&q="},


### PR DESCRIPTION
Jira Ticket: [WEB-272](https://bulibrary.atlassian.net/browse/WEB-272)

### Background
- want to be able to show/hide announcement banners from [the spreadsheet](https://docs.google.com/spreadsheets/d/1ElW0CUOV3LvcHuYxK2BZfFjo65a-XDrlNJtnrelA6tM/edit#gid=0) like we did for primo (with the wrlc), but everywhere else
- this allows custom announcements to be made and shown/hidden from a google spreadsheet, without any code changes
- this enables (and demonstrates) that

### Implementation Notes
- on connection to the HTML document (`connectedCallback`), check the code against a known list of keys.
- if it matches, fill in all of the data points with what's coming from the Google Sheets API
- NOTE: want to default all of the usages to have `dismissed` there, so it doesn't show unless it's overwritten by `show_banner`

### Description of Changes
- [x] when the given 'code' matches a known entry in our spreadsheet, use the Google Sheets API to auto-fill-in the message and 'show_banner'
- [x] add documentation to demonstrate

### Screenshots
side-by-side [announcement-banner (google sheets)](https://docs.google.com/spreadsheets/d/1ElW0CUOV3LvcHuYxK2BZfFjo65a-XDrlNJtnrelA6tM/edit#gid=0) and [enumerated storybook demo](https://bulib.github.io/bulib-wc/?path=/story/web-components-bulib-announce--sheets-api-enumerated)
![screenshot showing demo page displaying the sheets data](https://user-images.githubusercontent.com/5565284/77825228-589dab00-70de-11ea-9628-276d32f11d13.png)

other, written documentation
![screenshot of the documentation](https://user-images.githubusercontent.com/5565284/77825292-a61a1800-70de-11ea-8377-3ab83265375b.png)
